### PR TITLE
Symmetrize coupling map in `qubit_subset_finders.find_lines`

### DIFF
--- a/qopt_best_practices/qubit_selection/backend_evaluator.py
+++ b/qopt_best_practices/qubit_selection/backend_evaluator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from qiskit.transpiler import CouplingMap
+from qiskit.providers import Backend
 
 from .metric_evaluators import evaluate_fidelity
 from .qubit_subset_finders import find_lines
@@ -17,10 +18,11 @@ class BackendEvaluator:
     transpiler pass.
     """
 
-    def __init__(self, backend):
-
+    def __init__(self, backend: Backend):
         self.backend = backend
         self.coupling_map = CouplingMap(backend.configuration().coupling_map)
+        if not self.coupling_map.is_symmetric:
+            self.coupling_map.make_symmetric()
 
     def evaluate(
         self,
@@ -42,7 +44,7 @@ class BackendEvaluator:
             subset_finder = find_lines
 
         # TODO: add callbacks
-        qubit_subsets = subset_finder(num_qubits, self.backend, self.coupling_map)
+        qubit_subsets = subset_finder(num_qubits, self.backend)
 
         # evaluating the subsets
         scores = [

--- a/qopt_best_practices/qubit_selection/backend_evaluator.py
+++ b/qopt_best_practices/qubit_selection/backend_evaluator.py
@@ -20,7 +20,7 @@ class BackendEvaluator:
 
     def __init__(self, backend: Backend):
         self.backend = backend
-        self.coupling_map = CouplingMap(backend.configuration().coupling_map)
+        self.coupling_map = CouplingMap(backend.coupling_map)
         if not self.coupling_map.is_symmetric:
             self.coupling_map.make_symmetric()
 

--- a/qopt_best_practices/qubit_selection/metric_evaluators.py
+++ b/qopt_best_practices/qubit_selection/metric_evaluators.py
@@ -3,12 +3,12 @@ to evaluate 2-qubit gate fidelity."""
 
 from __future__ import annotations
 from qiskit.providers import Backend
-from rustworkx import EdgeList
+import rustworkx as rx
 
 TWO_Q_GATES = ["cx", "ecr", "cz"]
 
 
-def evaluate_fidelity(path: list[int], backend: Backend, edges: EdgeList) -> float:
+def evaluate_fidelity(path: list[int], backend: Backend, edges: rx.EdgeList) -> float:
     """Evaluates fidelity on a given list of qubits based on the two-qubit gate error
     for a specific backend.
 

--- a/qopt_best_practices/qubit_selection/metric_evaluators.py
+++ b/qopt_best_practices/qubit_selection/metric_evaluators.py
@@ -17,19 +17,18 @@ def evaluate_fidelity(path: list[int], backend: Backend, edges: EdgeList) -> flo
     """
 
     two_qubit_fidelity = {}
-    props = backend.properties()
+    target = backend.target
 
     try:
-        gate_name = list(set(TWO_Q_GATES).intersection(backend.basis_gates))[0]
+        gate_name = list(set(TWO_Q_GATES).intersection(backend.operation_names))[0]
     except IndexError:
         raise ValueError("Could not identify two-qubit gate")
 
     for edge in edges:
         try:
-            cx_error = props.gate_error(gate_name, edge)
-
+            cx_error = target[gate_name][edge].error
         except:  # pylint: disable=bare-except
-            cx_error = props.gate_error(gate_name, edge[::-1])
+            cx_error = target[gate_name][edge[::-1]].error
 
         two_qubit_fidelity[tuple(edge)] = 1 - cx_error
 

--- a/qopt_best_practices/qubit_selection/metric_evaluators.py
+++ b/qopt_best_practices/qubit_selection/metric_evaluators.py
@@ -2,10 +2,13 @@
 to evaluate 2-qubit gate fidelity."""
 
 from __future__ import annotations
+from qiskit.providers import Backend
+from rustworkx import EdgeList
 
-# TODO: backend & edges typehint. Currently, only BackendV1 is supported
-#       Might make sense to extend to BackendV2 for generality
-def evaluate_fidelity(path: list[int], backend, edges) -> float:
+TWO_Q_GATES = ["cx", "ecr", "cz"]
+
+
+def evaluate_fidelity(path: list[int], backend: Backend, edges: EdgeList) -> float:
     """Evaluates fidelity on a given list of qubits based on the two-qubit gate error
     for a specific backend.
 
@@ -16,11 +19,9 @@ def evaluate_fidelity(path: list[int], backend, edges) -> float:
     two_qubit_fidelity = {}
     props = backend.properties()
 
-    if "cx" in backend.configuration().basis_gates:
-        gate_name = "cx"
-    elif "ecr" in backend.configuration().basis_gates:
-        gate_name = "ecr"
-    else:
+    try:
+        gate_name = list(set(TWO_Q_GATES).intersection(backend.basis_gates))[0]
+    except IndexError:
         raise ValueError("Could not identify two-qubit gate")
 
     for edge in edges:

--- a/qopt_best_practices/qubit_selection/metric_evaluators.py
+++ b/qopt_best_practices/qubit_selection/metric_evaluators.py
@@ -21,8 +21,8 @@ def evaluate_fidelity(path: list[int], backend: Backend, edges: EdgeList) -> flo
 
     try:
         gate_name = list(set(TWO_Q_GATES).intersection(backend.operation_names))[0]
-    except IndexError:
-        raise ValueError("Could not identify two-qubit gate")
+    except IndexError as exc:
+        raise ValueError("Could not identify two-qubit gate") from exc
 
     for edge in edges:
         try:

--- a/qopt_best_practices/qubit_selection/qubit_subset_finders.py
+++ b/qopt_best_practices/qubit_selection/qubit_subset_finders.py
@@ -22,6 +22,8 @@ def find_lines(length: int, backend, coupling_map: CouplingMap | None = None) ->
     # might make sense to make backend the only input for simplicity
     if coupling_map is None:
         coupling_map = CouplingMap(backend.configuration().coupling_map)
+    if not coupling_map.is_symmetric:
+        coupling_map.make_symmetric()
 
     all_paths = rx.all_pairs_all_simple_paths(
         coupling_map.graph,

--- a/qopt_best_practices/qubit_selection/qubit_subset_finders.py
+++ b/qopt_best_practices/qubit_selection/qubit_subset_finders.py
@@ -8,6 +8,7 @@ import rustworkx as rx
 from qiskit.transpiler import CouplingMap
 from qiskit.providers import Backend
 
+
 def find_lines(length: int, backend: Backend) -> list[int]:
     """Finds all possible lines of length `length` for a specific backend topology.
 

--- a/qopt_best_practices/qubit_selection/qubit_subset_finders.py
+++ b/qopt_best_practices/qubit_selection/qubit_subset_finders.py
@@ -18,7 +18,7 @@ def find_lines(length: int, backend: Backend) -> list[int]:
         The found paths.
     """
 
-    coupling_map = CouplingMap(backend.configuration().coupling_map)
+    coupling_map = CouplingMap(backend.coupling_map)
     if not coupling_map.is_symmetric:
         coupling_map.make_symmetric()
 

--- a/qopt_best_practices/qubit_selection/qubit_subset_finders.py
+++ b/qopt_best_practices/qubit_selection/qubit_subset_finders.py
@@ -6,10 +6,9 @@ import numpy as np
 import rustworkx as rx
 
 from qiskit.transpiler import CouplingMap
+from qiskit.providers import Backend
 
-# TODO: backend typehint. Currently, only BackendV1 is supported
-#       Might make sense to extend to BackendV2 for generality
-def find_lines(length: int, backend, coupling_map: CouplingMap | None = None) -> list[int]:
+def find_lines(length: int, backend: Backend) -> list[int]:
     """Finds all possible lines of length `length` for a specific backend topology.
 
     This method can take quite some time to run on large devices since there
@@ -19,9 +18,7 @@ def find_lines(length: int, backend, coupling_map: CouplingMap | None = None) ->
         The found paths.
     """
 
-    # might make sense to make backend the only input for simplicity
-    if coupling_map is None:
-        coupling_map = CouplingMap(backend.configuration().coupling_map)
+    coupling_map = CouplingMap(backend.configuration().coupling_map)
     if not coupling_map.is_symmetric:
         coupling_map.make_symmetric()
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary
Solves #13 

### Details and comments
- Adding a check for symmetry (directedness) of the coupling map and symmetrizing if necessary in `qubit_subset_finders.find_lines` and `backend_evaluator`.
- removed argument `coupling_map` in `qubit_subset_finders.find_lines` as suggested by a comment
- added type hints for backend arguments and removed respective comment
- added cleaner check for device native two-qubit-gate
- adapted all accesses of backend properties to BackendV2
- added test for directed coupling maps
