### PR TITLE
SWAP removal

### DIFF
--- a/qopt_best_practices/transpilation/preset_qaoa_passmanager.py
+++ b/qopt_best_practices/transpilation/preset_qaoa_passmanager.py
@@ -11,6 +11,7 @@ from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import (
 from qiskit.circuit.library import CXGate
 
 from qopt_best_practices.transpilation.qaoa_construction_pass import QAOAConstructionPass
+from qopt_best_practices.transpilation.swap_cancellation_pass import SwapToFinalMapping
 
 
 def qaoa_swap_strategy_pm(config: Dict[str, Any]):
@@ -39,6 +40,7 @@ def qaoa_swap_strategy_pm(config: Dict[str, Any]):
                 swap_strategy,
                 edge_coloring,
             ),
+            SwapToFinalMapping(),
             HighLevelSynthesis(basis_gates=basis_gates),
             InverseCancellation(gates_to_cancel=[CXGate()]),
             QAOAConstructionPass(num_layers),

--- a/qopt_best_practices/transpilation/swap_cancellation_pass.py
+++ b/qopt_best_practices/transpilation/swap_cancellation_pass.py
@@ -18,7 +18,7 @@ class SwapToFinalMapping(TransformationPass):
 
         qmap = self.property_set["virtual_permutation_layout"]
 
-        qreg = dag.qregs["q"]
+        qreg = dag.qregs[next(iter(dag.qregs))]
 
         # This will remove SWAP gates that are applied before anything else
         # This remove is executed multiple times until there are no more SWAP

--- a/qopt_best_practices/transpilation/swap_cancellation_pass.py
+++ b/qopt_best_practices/transpilation/swap_cancellation_pass.py
@@ -1,0 +1,44 @@
+"""Pass to remove SWAP gates that are not needed."""
+
+from qiskit.dagcircuit import DAGOutNode, DAGCircuit
+from qiskit.transpiler import TransformationPass
+
+
+class SwapToFinalMapping(TransformationPass):
+    """Absorb any redundent SWAPs in the final layout.
+
+    This pass should be executed after a SWAPStrategy has been applied to a block
+    of commuting gates. It will remove any final redundent SWAP gates and absorb
+    them into the virtual layout. This effectively undoes any possibly redundent
+    SWAP gates that the SWAPStrategy may have inserted.
+    """
+
+    def run(self, dag: DAGCircuit):
+        """run the pass."""
+
+        qmap = self.property_set["virtual_permutation_layout"]
+
+        qreg = dag.qregs["q"]
+
+        # This will remove SWAP gates that are applied before anything else
+        # This remove is executed multiple times until there are no more SWAP
+        # gates left to remove. Note: a more inteligent DAG traversal could
+        # be implemented here.
+
+        done = False
+
+        while not done:
+            permuted = False
+            for node in dag.topological_op_nodes():
+                if node.op.name == "swap":
+                    successors = list(dag.successors(node))
+                    if len(successors) == 2:
+                        if all(isinstance(successors[idx], DAGOutNode) for idx in [0, 1]):
+                            bits = [qreg.index(qubit) for qubit in node.qargs]
+                            qmap[bits[0]], qmap[bits[1]] = qmap[bits[1]], qmap[bits[0]]
+                            dag.remove_op_node(node)
+                            permuted = True
+
+            done = not permuted
+
+        return dag


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary

This pass removes SWAP gates that do not have an effect on the final circuit.

### Details and comments

1. A new pass is introduced. This pass should be applied after the commuting 2Q block routing to remove any redundant SWAP gates that the swap strategy may have inserted.
2. This pass is added to the predefined pass manager.
3. A test is added.