### PR TITLE
Fix `remove_instruction_from_target` to handle `if_else` properly

### DIFF
--- a/qopt_best_practices/transpilation/backend_utils.py
+++ b/qopt_best_practices/transpilation/backend_utils.py
@@ -29,6 +29,8 @@ def remove_instruction_from_target(target: Target, gate_name: str) -> Target:
             continue  # Skip the gate you want to remove
 
         instruction = target.operation_from_name(name)
+        if qarg_map == {None: None}:
+            qarg_map = None
         new_target.add_instruction(instruction, qarg_map, name=name)
 
     return new_target


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary

It appears that devices may have started emitting the if_else instruction.
As a result, the fractional gates tutorial currently fails due to this instruction.
This pull request introduces a fix to ensure compatibility.

The error due to if_else.
> qiskit.transpiler.exceptions.TranspilerError: "An instruction added globally by class can't have properties set."

### Details and comments


