### PR TITLE
Error on disconnected ansatz, support Rz terms in cost layer

### DIFF
--- a/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
+++ b/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
@@ -302,4 +302,9 @@ def annotated_qaoa_ansatz(  # pylint: disable=too-many-positional-arguments
         ),
         copy=False,
     )
+
+    for inst in out_circuit:
+        if inst.operation.name == "box":
+            if inst.operation.num_qubits != out_circuit.num_qubits:
+                raise NotImplementedError("This constructor does not support incomplete graphs.")
     return out_circuit

--- a/test/test_annotated_qaoa_ansatz.py
+++ b/test/test_annotated_qaoa_ansatz.py
@@ -78,6 +78,30 @@ class TestAnnotatedQAOAAnsatz(unittest.TestCase):
             else:
                 self.assertEqual(instr.operation.annotations[0].payload, "3")
 
+    def test_disconnected_graph(self):
+        """Check that the constructor will fail if the graph is disconnected."""
+
+        cost_op = SparsePauliOp.from_list(
+            [
+                ("IIIIIIIIIIIZIIIIIIIIZIIIIIIIIIIIIIIIIII", (-0.7052117420058351 + 0j)),
+                ("IIIIIIIIIIIZIIIIZIIIIIIIIIIIIIIIIIIIIII", (-0.41310912458730803 + 0j)),
+                ("IIIIIIIIIIIIIIIIZZIIIIIIIIIIIIIIIIIIIII", (-0.13889026348769137 + 0j)),
+                ("IIIIIIIIIIIIIIIIIIIIIIIIIIIIZZIIIIIIIII", (-1.2611637053747173 + 0j)),
+                ("IIIIIIIIIIIIIIIIIIIIIIIIIIIIIZIIZIIIIII", (-0.7849745661237995 + 0j)),
+                ("IIIIIIIIIIIIIIIIIIIIIIIIIIIIIZIIIIIIIIZ", (0.7613352014865872 + 0j)),
+                ("IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIZZ", (-1.171616190854362 + 0j)),
+                ("IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIZZI", (0.04701291466680199 + 0j)),
+                ("IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIZIIIIIZI", (-0.40542381697372243 + 0j)),
+                ("IIIIIIIIIIIIIIIIIIIIIIIIIIZZIIIIIIIIIII", (-0.6962346022159056 + 0j)),
+                ("IIIIIIIIIIIIIIIIIIIIIIIIIIIZIIIIIIIIZII", (0.1925567945293817 + 0j)),
+                ("IIIIIIIIIIIIIIIIIIIIIIZZIIIIIIIIIIIIIII", (-0.2766391151103169 + 0j)),
+                ("IIIIIIIIIIIIIZIIIIIIIIZIIIIIIIIIIIIIIII", (-0.010835558499671294 + 0j)),
+            ]
+        )
+
+        with self.assertRaises(NotImplementedError):
+            _ = annotated_qaoa_ansatz(cost_op, reps=2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary
This PR fixes two use cases that used to fail: 

- disconnected graphs generate a box that is smaller than the circuit width, which caused issues with the transpilation pipeline. The annotated ansatz now raises an error when the cost operator is not complete/
- fixed a bug in handling Rz gates in the cost operator


### Details and comments


