### PR TITLE
Allow compatibility with qiskit 2.3.0

### DIFF
--- a/qopt_best_practices/transpilation/annotated_transpilation_passes.py
+++ b/qopt_best_practices/transpilation/annotated_transpilation_passes.py
@@ -40,6 +40,7 @@ class AnnotatedPrepareCostLayer(TransformationPass):
 
     def run(self, dag):
         """Run the pass."""
+        new_dag = dag.copy_empty_like()
         for node in dag.topological_op_nodes():
             if node.op.name == "box":
                 if "cost_layer" in node.op.annotations[0].namespace:
@@ -79,6 +80,8 @@ class AnnotatedPrepareCostLayer(TransformationPass):
                         )
 
                     node.op.params[0] = dag_to_circuit(box_dag)
+            new_dag.apply_operation_back(node.op, qargs=node.qargs, cargs=node.cargs)
+        return new_dag
 
 
 class AnnotatedCommuting2qGateRouter(TransformationPass):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-sat
 networkx
-qiskit>=1.0, <2.3.0
+qiskit>=1.0
 qiskit-ibm-runtime

--- a/test/test_preset_qaoa_pass_manager.py
+++ b/test/test_preset_qaoa_pass_manager.py
@@ -1,5 +1,6 @@
 """Test the preset QAOA pass manager."""
 
+import re
 from unittest import TestCase
 
 from qiskit.primitives import StatevectorEstimator
@@ -7,11 +8,16 @@ from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.transpiler import CouplingMap, PassManager
 from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import SwapStrategy
+from qiskit import __version__ as qiskit_version
 
 from qopt_best_practices.circuit_library import annotated_qaoa_ansatz
 from qopt_best_practices.transpilation.annotated_transpilation_passes import UnrollBoxes
 from qopt_best_practices.transpilation.generate_preset_qaoa_pass_manager import (
     generate_preset_qaoa_pass_manager,
+)
+
+QISKIT_VERSION = tuple(
+    int(x) for x in re.match(r"\d+\.\d+\.\d", qiskit_version).group(0).split(".")[:3]
 )
 
 
@@ -49,7 +55,10 @@ class TestPresetQAOAPassManager(TestCase):
         qreg = isa_ansatz.qregs[0]
         creg = isa_ansatz.cregs[0]
 
-        expected_meas_map = {0: 1, 1: 0, 2: 3, 3: 2}
+        if QISKIT_VERSION[0] <= 2 and QISKIT_VERSION[1] < 3:
+            expected_meas_map = {0: 1, 1: 0, 2: 3, 3: 2}
+        else:
+            expected_meas_map = {0: 2, 1: 3, 2: 0, 3: 1}
 
         for inst in isa_ansatz.data:
             if inst.operation.name == "measure":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary
Address 2.3.0 "breaking" changes (not officially breaking but affected this package):

- migration of control flow ops to Rust, including `BoxOp`, which meant overwriting box op contents was no longer possible through the Python API. Fixed by creating a new dag instead of overwriting the existing dag.
- improvements to vf2layout that changed the heuristic and lead to a different (valid) output layout


### Details and comments
After this PR we can remove the pin introduced in #53.
