### PR TITLE
Add parametric Hamiltonian support to SAT mapper

### DIFF
--- a/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
+++ b/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import itertools
 import typing
 import warnings
 from collections.abc import Sequence
-
+import itertools
 import numpy as np
+
 from qiskit.circuit import QuantumCircuit, annotation
 from qiskit.circuit.parametervector import ParameterVector
 from qiskit.quantum_info import Operator, Pauli, SparsePauliOp
@@ -144,9 +144,7 @@ def annotated_evolved_operator_ansatz(  # pylint: disable=too-many-positional-ar
         #    [[a0, a1, a2, ...], [b0, b1, b2, ...], [c0, c1, c2, ...]]
         # and turns them into an iterator
         #    a0 -> b0 -> c0 -> a1 -> b1 -> c1 -> a2 -> ...
-        per_operator = [
-            ParameterVector(prefix, reps).params for prefix in parameter_prefix
-        ]
+        per_operator = [ParameterVector(prefix, reps).params for prefix in parameter_prefix]
         param_iter = itertools.chain.from_iterable(zip(*per_operator))
 
     # slower, Python-path
@@ -212,17 +210,13 @@ def _is_pauli_identity(operator):
 
 
 def _remove_identities(operators, prefixes):
-    identity_ops = {
-        index for index, op in enumerate(operators) if _is_pauli_identity(op)
-    }
+    identity_ops = {index for index, op in enumerate(operators) if _is_pauli_identity(op)}
 
     if len(identity_ops) == 0:
         return operators, prefixes
 
     cleaned_ops = [op for i, op in enumerate(operators) if i not in identity_ops]
-    cleaned_prefix = [
-        prefix for i, prefix in enumerate(prefixes) if i not in identity_ops
-    ]
+    cleaned_prefix = [prefix for i, prefix in enumerate(prefixes) if i not in identity_ops]
 
     return cleaned_ops, cleaned_prefix
 
@@ -313,8 +307,8 @@ def annotated_qaoa_ansatz(  # pylint: disable=too-many-positional-arguments
         if inst.operation.name == "box":
             if inst.operation.num_qubits not in (0, out_circuit.num_qubits):
                 raise NotImplementedError(
-                    f"This constructor does not support incomplete graphs. "
-                    f"Expected instruction to act on {out_circuit.num_qubits}, "
-                    f"instead, got {inst.operation.num_qubits}."
+                    "This constructor does not support incomplete graphs. ",
+                    f"Expected instruction to act on {out_circuit.num_qubits}, ",
+                    f"instead, got {inst.operation.num_qubits}.",
                 )
     return out_circuit

--- a/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
+++ b/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+import itertools
 import typing
 import warnings
 from collections.abc import Sequence
-import itertools
-import numpy as np
 
+import numpy as np
 from qiskit.circuit import QuantumCircuit, annotation
 from qiskit.circuit.parametervector import ParameterVector
 from qiskit.quantum_info import Operator, Pauli, SparsePauliOp
@@ -144,7 +144,9 @@ def annotated_evolved_operator_ansatz(  # pylint: disable=too-many-positional-ar
         #    [[a0, a1, a2, ...], [b0, b1, b2, ...], [c0, c1, c2, ...]]
         # and turns them into an iterator
         #    a0 -> b0 -> c0 -> a1 -> b1 -> c1 -> a2 -> ...
-        per_operator = [ParameterVector(prefix, reps).params for prefix in parameter_prefix]
+        per_operator = [
+            ParameterVector(prefix, reps).params for prefix in parameter_prefix
+        ]
         param_iter = itertools.chain.from_iterable(zip(*per_operator))
 
     # slower, Python-path
@@ -210,13 +212,17 @@ def _is_pauli_identity(operator):
 
 
 def _remove_identities(operators, prefixes):
-    identity_ops = {index for index, op in enumerate(operators) if _is_pauli_identity(op)}
+    identity_ops = {
+        index for index, op in enumerate(operators) if _is_pauli_identity(op)
+    }
 
     if len(identity_ops) == 0:
         return operators, prefixes
 
     cleaned_ops = [op for i, op in enumerate(operators) if i not in identity_ops]
-    cleaned_prefix = [prefix for i, prefix in enumerate(prefixes) if i not in identity_ops]
+    cleaned_prefix = [
+        prefix for i, prefix in enumerate(prefixes) if i not in identity_ops
+    ]
 
     return cleaned_ops, cleaned_prefix
 
@@ -307,8 +313,8 @@ def annotated_qaoa_ansatz(  # pylint: disable=too-many-positional-arguments
         if inst.operation.name == "box":
             if inst.operation.num_qubits not in (0, out_circuit.num_qubits):
                 raise NotImplementedError(
-                    "This constructor does not support incomplete graphs. ",
-                    f"Expected instruction to act on {out_circuit.num_qubits}, ",
-                    f"instead, got {inst.operation.num_qubits}.",
+                    f"This constructor does not support incomplete graphs. "
+                    f"Expected instruction to act on {out_circuit.num_qubits}, "
+                    f"instead, got {inst.operation.num_qubits}."
                 )
     return out_circuit

--- a/qopt_best_practices/sat_mapping/sat_mapper.py
+++ b/qopt_best_practices/sat_mapping/sat_mapper.py
@@ -22,10 +22,10 @@ from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import SwapStrat
 class SATResult:
     """A data class to hold the result of a SAT solver."""
 
-    satisfiable: (bool)  # Satisfiable is True if the SAT model could be solved in a given time.
-    solution: dict  # The solution to the SAT problem if it is satisfiable.
-    mapping: (list)  # The mapping of nodes in the pattern graph to nodes in the target graph.
-    elapsed_time: float  # The time it took to solve the SAT model.
+    satisfiable: bool  # True if SAT model was solved within timeout.
+    solution: dict  # The solution to the SAT problem if satisfiable.
+    mapping: list  # Node mapping from pattern graph to target graph.
+    elapsed_time: float  # Time taken to solve the SAT model.
 
 
 class SATMapper:
@@ -125,7 +125,9 @@ class SATMapper:
             # full connectivity then its distance matrix will have entries with -1. These
             # entries must be treated as False.
             d_matrix = swap_strategy.distance_matrix
-            connectivity_matrix = ((-1 < d_matrix) & (d_matrix <= num_layers)).astype(int)
+            connectivity_matrix = ((-1 < d_matrix) & (d_matrix <= num_layers)).astype(
+                int
+            )
             # Make a cnf for the adjacency constraint
             cnf2 = []
             for e_0, e_1 in program_graph.edges:
@@ -156,11 +158,15 @@ class SATMapper:
                 if status:
                     # If the SAT problem is satisfiable, convert the solution to a mapping.
                     mapping = [vid2mapping[idx] for idx in sol if idx > 0]
-                    binary_search_results[num_layers] = SATResult(status, sol, mapping, e_time)
+                    binary_search_results[num_layers] = SATResult(
+                        status, sol, mapping, e_time
+                    )
                     max_layers = num_layers
                 else:
                     # If the SAT problem is unsatisfiable, return the last satisfiable solution.
-                    binary_search_results[num_layers] = SATResult(status, sol, [], e_time)
+                    binary_search_results[num_layers] = SATResult(
+                        status, sol, [], e_time
+                    )
                     min_layers = num_layers + 1
 
         return binary_search_results
@@ -173,10 +179,10 @@ class SATMapper:
         """Applies the SAT mapping.
 
         Args:
-            graph: The graph to remap. If a cost operator is provided then it will
-                internally be converted to a graph for structure analysis, but the
-                original operator (including parametric coefficients) will be preserved
-                in the output.
+            graph: The graph or operator to remap. Can be either a NetworkX Graph or a
+                SparsePauliOp. If a SparsePauliOp is provided, it will be internally
+                converted to a graph for structure analysis, while the original operator
+                (including parametric coefficients) is preserved in the output.
             swap_strategy: The swap strategy to use to find the initial mapping.
 
         Returns:
@@ -202,7 +208,7 @@ class SATMapper:
             remapped_graph = nx.relabel_nodes(graph, edge_map)
 
             if op_input:
-                # Remap the original operator to preserve parametric coefficients
+                # Remap the original operator directly to preserve parametric coefficients
                 remapped_op = self.remap_operator(original_op, edge_map)
                 return remapped_op, edge_map, min_k
 
@@ -211,7 +217,9 @@ class SATMapper:
             return None, None, None
 
     @staticmethod
-    def remap_operator(operator: SparsePauliOp, qubit_map: dict[int, int]) -> SparsePauliOp:
+    def remap_operator(
+        operator: SparsePauliOp, qubit_map: dict[int, int]
+    ) -> SparsePauliOp:
         """Remap qubits in a SparsePauliOp according to a qubit mapping.
 
         Args:
@@ -259,7 +267,8 @@ class SATMapper:
         Args:
             operator: The SparsePauliOp to convert. If the operator contains
                 parametric coefficients (ParameterExpression), they will be
-                treated as having weight 1.0 for graph structure purposes.
+                converted to weight 1.0 for graph structure analysis, since only
+                the connectivity pattern (not weights) matters for SAT mapping.
 
         Returns:
             A NetworkX graph representing the operator structure.
@@ -272,7 +281,7 @@ class SATMapper:
         for pauli_str, weight in operator.to_list():
             edge = [idx for idx, char in enumerate(pauli_str[::-1]) if char == "Z"]
 
-            # Handle parametric weights by using 1.0 as default
+            # Convert parametric weights to 1.0 for graph structure analysis
             if isinstance(weight, ParameterExpression):
                 numeric_weight = 1.0
             else:

--- a/qopt_best_practices/sat_mapping/sat_mapper.py
+++ b/qopt_best_practices/sat_mapping/sat_mapper.py
@@ -231,22 +231,20 @@ class SATMapper:
             Preserves all coefficients including parametric ones.
         """
         num_qubits = operator.num_qubits
-        pauli_list = []
+        pauli_strings = []
 
-        for pauli_str, coeff in zip(operator.paulis, operator.coeffs):
+        for pauli_str in operator.paulis:
             # Create new Pauli string with remapped qubits
             new_paulis = ["I"] * num_qubits
-            for qubit_idx, pauli_char in enumerate(str(pauli_str)[::-1]):
+            for qubit_idx, pauli_char in enumerate(pauli_str.to_label()[::-1]):
                 if pauli_char != "I":
                     new_qubit_idx = qubit_map.get(qubit_idx, qubit_idx)
                     new_paulis[new_qubit_idx] = pauli_char
 
-            pauli_list.append(("".join(new_paulis)[::-1], coeff))
+            pauli_strings.append("".join(new_paulis)[::-1])
 
         # Use SparsePauliOp constructor to preserve parametric coefficients
-        pauli_strings = [p[0] for p in pauli_list]
-        coeffs = [p[1] for p in pauli_list]
-        return SparsePauliOp(pauli_strings, coeffs)
+        return SparsePauliOp(pauli_strings, operator.coeffs)
 
     @staticmethod
     def graph2op(graph: nx.Graph) -> SparsePauliOp:
@@ -292,7 +290,10 @@ class SATMapper:
             elif len(edge) == 2:
                 edges.append((edge[0], edge[1], numeric_weight))
             else:
-                raise ValueError(f"The operator {operator} is not Quadratic.")
+                raise ValueError(
+                    f"Only quadratic operators can be converted to a graph structure, "
+                    f"received {operator}, which is not quadratic."
+                )
 
         graph.add_weighted_edges_from(edges)
 

--- a/qopt_best_practices/sat_mapping/sat_mapper.py
+++ b/qopt_best_practices/sat_mapping/sat_mapper.py
@@ -3,18 +3,17 @@ using the SAT approach from https://arxiv.org/abs/2212.05666.
 """
 
 from __future__ import annotations
-from typing import Union
 
 from dataclasses import dataclass
 from itertools import combinations
 from threading import Timer
+from typing import Union
 
 import networkx as nx
 import numpy as np
-
 from pysat.formula import CNF, IDPool
 from pysat.solvers import Solver
-
+from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import SwapStrategy
 
@@ -23,9 +22,9 @@ from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import SwapStrat
 class SATResult:
     """A data class to hold the result of a SAT solver."""
 
-    satisfiable: bool  # Satisfiable is True if the SAT model could be solved in a given time.
+    satisfiable: (bool)  # Satisfiable is True if the SAT model could be solved in a given time.
     solution: dict  # The solution to the SAT problem if it is satisfiable.
-    mapping: list  # The mapping of nodes in the pattern graph to nodes in the target graph.
+    mapping: (list)  # The mapping of nodes in the pattern graph to nodes in the target graph.
     elapsed_time: float  # The time it took to solve the SAT model.
 
 
@@ -175,17 +174,20 @@ class SATMapper:
 
         Args:
             graph: The graph to remap. If a cost operator is provided then it will
-                internally be converted to a graph.
+                internally be converted to a graph for structure analysis, but the
+                original operator (including parametric coefficients) will be preserved
+                in the output.
             swap_strategy: The swap strategy to use to find the initial mapping.
 
         Returns:
-            tuple: A tuple containing the remapped graph, the edge map, and the number of layers of
-            the swap strategy that was used to find the initial mapping. If no solution is found
-            then the tuple contains None for each element.
+            tuple: A tuple containing the remapped graph/operator, the edge map, and the
+            number of layers of the swap strategy that was used to find the initial mapping.
+            If no solution is found then the tuple contains None for each element.
             Note the returned edge map `{k: v}` means that node `k` in the original
             graph gets mapped to node `v` in the Pauli strings.
         """
         op_input = isinstance(graph, SparsePauliOp)
+        original_op = graph if op_input else None
 
         if op_input:
             graph = self.op2graph(graph)
@@ -200,11 +202,43 @@ class SATMapper:
             remapped_graph = nx.relabel_nodes(graph, edge_map)
 
             if op_input:
-                return self.graph2op(remapped_graph), edge_map, min_k
+                # Remap the original operator to preserve parametric coefficients
+                remapped_op = self.remap_operator(original_op, edge_map)
+                return remapped_op, edge_map, min_k
 
             return remapped_graph, edge_map, min_k
         else:
             return None, None, None
+
+    @staticmethod
+    def remap_operator(operator: SparsePauliOp, qubit_map: dict[int, int]) -> SparsePauliOp:
+        """Remap qubits in a SparsePauliOp according to a qubit mapping.
+
+        Args:
+            operator: The operator to remap.
+            qubit_map: Dictionary mapping original qubit indices to new indices.
+
+        Returns:
+            A new SparsePauliOp with qubits remapped according to qubit_map.
+            Preserves all coefficients including parametric ones.
+        """
+        num_qubits = operator.num_qubits
+        pauli_list = []
+
+        for pauli_str, coeff in zip(operator.paulis, operator.coeffs):
+            # Create new Pauli string with remapped qubits
+            new_paulis = ["I"] * num_qubits
+            for qubit_idx, pauli_char in enumerate(str(pauli_str)[::-1]):
+                if pauli_char != "I":
+                    new_qubit_idx = qubit_map.get(qubit_idx, qubit_idx)
+                    new_paulis[new_qubit_idx] = pauli_char
+
+            pauli_list.append(("".join(new_paulis)[::-1], coeff))
+
+        # Use SparsePauliOp constructor to preserve parametric coefficients
+        pauli_strings = [p[0] for p in pauli_list]
+        coeffs = [p[1] for p in pauli_list]
+        return SparsePauliOp(pauli_strings, coeffs)
 
     @staticmethod
     def graph2op(graph: nx.Graph) -> SparsePauliOp:
@@ -220,15 +254,34 @@ class SATMapper:
 
     @staticmethod
     def op2graph(operator: SparsePauliOp) -> nx.Graph:
-        """Convert a cost operator to a graph."""
+        """Convert a cost operator to a graph.
+
+        Args:
+            operator: The SparsePauliOp to convert. If the operator contains
+                parametric coefficients (ParameterExpression), they will be
+                treated as having weight 1.0 for graph structure purposes.
+
+        Returns:
+            A NetworkX graph representing the operator structure.
+
+        Raises:
+            ValueError: If the operator is not quadratic (contains terms with
+                more than 2 Z operators).
+        """
         graph, edges = nx.Graph(), []
         for pauli_str, weight in operator.to_list():
             edge = [idx for idx, char in enumerate(pauli_str[::-1]) if char == "Z"]
 
+            # Handle parametric weights by using 1.0 as default
+            if isinstance(weight, ParameterExpression):
+                numeric_weight = 1.0
+            else:
+                numeric_weight = np.real(weight)
+
             if len(edge) == 1:
-                edges.append((edge[0], edge[0], np.real(weight)))
+                edges.append((edge[0], edge[0], numeric_weight))
             elif len(edge) == 2:
-                edges.append((edge[0], edge[1], np.real(weight)))
+                edges.append((edge[0], edge[1], numeric_weight))
             else:
                 raise ValueError(f"The operator {operator} is not Quadratic.")
 

--- a/qopt_best_practices/sat_mapping/sat_mapper.py
+++ b/qopt_best_practices/sat_mapping/sat_mapper.py
@@ -125,9 +125,7 @@ class SATMapper:
             # full connectivity then its distance matrix will have entries with -1. These
             # entries must be treated as False.
             d_matrix = swap_strategy.distance_matrix
-            connectivity_matrix = ((-1 < d_matrix) & (d_matrix <= num_layers)).astype(
-                int
-            )
+            connectivity_matrix = ((-1 < d_matrix) & (d_matrix <= num_layers)).astype(int)
             # Make a cnf for the adjacency constraint
             cnf2 = []
             for e_0, e_1 in program_graph.edges:
@@ -158,15 +156,11 @@ class SATMapper:
                 if status:
                     # If the SAT problem is satisfiable, convert the solution to a mapping.
                     mapping = [vid2mapping[idx] for idx in sol if idx > 0]
-                    binary_search_results[num_layers] = SATResult(
-                        status, sol, mapping, e_time
-                    )
+                    binary_search_results[num_layers] = SATResult(status, sol, mapping, e_time)
                     max_layers = num_layers
                 else:
                     # If the SAT problem is unsatisfiable, return the last satisfiable solution.
-                    binary_search_results[num_layers] = SATResult(
-                        status, sol, [], e_time
-                    )
+                    binary_search_results[num_layers] = SATResult(status, sol, [], e_time)
                     min_layers = num_layers + 1
 
         return binary_search_results
@@ -217,9 +211,7 @@ class SATMapper:
             return None, None, None
 
     @staticmethod
-    def remap_operator(
-        operator: SparsePauliOp, qubit_map: dict[int, int]
-    ) -> SparsePauliOp:
+    def remap_operator(operator: SparsePauliOp, qubit_map: dict[int, int]) -> SparsePauliOp:
         """Remap qubits in a SparsePauliOp according to a qubit mapping.
 
         Args:

--- a/qopt_best_practices/sat_mapping/sat_mapper.py
+++ b/qopt_best_practices/sat_mapping/sat_mapper.py
@@ -125,7 +125,9 @@ class SATMapper:
             # full connectivity then its distance matrix will have entries with -1. These
             # entries must be treated as False.
             d_matrix = swap_strategy.distance_matrix
-            connectivity_matrix = ((-1 < d_matrix) & (d_matrix <= num_layers)).astype(int)
+            connectivity_matrix = ((-1 < d_matrix) & (d_matrix <= num_layers)).astype(
+                int
+            )
             # Make a cnf for the adjacency constraint
             cnf2 = []
             for e_0, e_1 in program_graph.edges:
@@ -156,11 +158,15 @@ class SATMapper:
                 if status:
                     # If the SAT problem is satisfiable, convert the solution to a mapping.
                     mapping = [vid2mapping[idx] for idx in sol if idx > 0]
-                    binary_search_results[num_layers] = SATResult(status, sol, mapping, e_time)
+                    binary_search_results[num_layers] = SATResult(
+                        status, sol, mapping, e_time
+                    )
                     max_layers = num_layers
                 else:
                     # If the SAT problem is unsatisfiable, return the last satisfiable solution.
-                    binary_search_results[num_layers] = SATResult(status, sol, [], e_time)
+                    binary_search_results[num_layers] = SATResult(
+                        status, sol, [], e_time
+                    )
                     min_layers = num_layers + 1
 
         return binary_search_results
@@ -202,41 +208,17 @@ class SATMapper:
             remapped_graph = nx.relabel_nodes(graph, edge_map)
 
             if op_input:
-                # Remap the original operator directly to preserve parametric coefficients
-                remapped_op = self.remap_operator(original_op, edge_map)
+                # Use Qiskit's built-in apply_layout to remap the operator
+                # apply_layout requires a list where list[i] = new position of qubit i
+                layout_list = [
+                    edge_map.get(i, i) for i in range(original_op.num_qubits)
+                ]
+                remapped_op = original_op.apply_layout(layout_list)
                 return remapped_op, edge_map, min_k
 
             return remapped_graph, edge_map, min_k
         else:
             return None, None, None
-
-    @staticmethod
-    def remap_operator(operator: SparsePauliOp, qubit_map: dict[int, int]) -> SparsePauliOp:
-        """Remap qubits in a SparsePauliOp according to a qubit mapping.
-
-        Args:
-            operator: The operator to remap.
-            qubit_map: Dictionary mapping original qubit indices to new indices.
-
-        Returns:
-            A new SparsePauliOp with qubits remapped according to qubit_map.
-            Preserves all coefficients including parametric ones.
-        """
-        num_qubits = operator.num_qubits
-        pauli_strings = []
-
-        for pauli_str in operator.paulis:
-            # Create new Pauli string with remapped qubits
-            new_paulis = ["I"] * num_qubits
-            for qubit_idx, pauli_char in enumerate(pauli_str.to_label()[::-1]):
-                if pauli_char != "I":
-                    new_qubit_idx = qubit_map.get(qubit_idx, qubit_idx)
-                    new_paulis[new_qubit_idx] = pauli_char
-
-            pauli_strings.append("".join(new_paulis)[::-1])
-
-        # Use SparsePauliOp constructor to preserve parametric coefficients
-        return SparsePauliOp(pauli_strings, operator.coeffs)
 
     @staticmethod
     def graph2op(graph: nx.Graph) -> SparsePauliOp:

--- a/qopt_best_practices/sat_mapping/sat_mapper.py
+++ b/qopt_best_practices/sat_mapping/sat_mapper.py
@@ -13,7 +13,6 @@ import networkx as nx
 import numpy as np
 from pysat.formula import CNF, IDPool
 from pysat.solvers import Solver
-from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import SwapStrategy
 
@@ -208,7 +207,7 @@ class SATMapper:
             remapped_graph = nx.relabel_nodes(graph, edge_map)
 
             if op_input:
-                # Use Qiskit's built-in apply_layout to remap the operator
+                # Remap the operator.
                 # apply_layout requires a list where list[i] = new position of qubit i
                 layout_list = [
                     edge_map.get(i, i) for i in range(original_op.num_qubits)
@@ -237,10 +236,9 @@ class SATMapper:
         """Convert a cost operator to a graph.
 
         Args:
-            operator: The SparsePauliOp to convert. If the operator contains
-                parametric coefficients (ParameterExpression), they will be
-                converted to weight 1.0 for graph structure analysis, since only
-                the connectivity pattern (not weights) matters for SAT mapping.
+            operator: The SparsePauliOp to convert. Edge weights are preserved
+                as-is, including ParameterExpression objects. The SAT mapping
+                algorithm only uses graph structure (connectivity), not weights.
 
         Returns:
             A NetworkX graph representing the operator structure.
@@ -253,16 +251,12 @@ class SATMapper:
         for pauli_str, weight in operator.to_list():
             edge = [idx for idx, char in enumerate(pauli_str[::-1]) if char == "Z"]
 
-            # Convert parametric weights to 1.0 for graph structure analysis
-            if isinstance(weight, ParameterExpression):
-                numeric_weight = 1.0
-            else:
-                numeric_weight = np.real(weight)
-
             if len(edge) == 1:
-                edges.append((edge[0], edge[0], numeric_weight))
+                # Self-loop for single Z terms
+                edges.append((edge[0], edge[0], weight))
             elif len(edge) == 2:
-                edges.append((edge[0], edge[1], numeric_weight))
+                # Edge for ZZ terms
+                edges.append((edge[0], edge[1], weight))
             else:
                 raise ValueError(
                     f"Only quadratic operators can be converted to a graph structure, "

--- a/test/test_sat_mapping.py
+++ b/test/test_sat_mapping.py
@@ -22,9 +22,7 @@ class TestSwapStrategies(TestCase):
         super().setUp()
 
         # load data
-        graph_file = os.path.join(
-            os.path.dirname(__file__), "data/graph_2layers_0seed.json"
-        )
+        graph_file = os.path.join(os.path.dirname(__file__), "data/graph_2layers_0seed.json")
 
         with open(graph_file, "r") as file:
             data = json.load(file)
@@ -35,13 +33,9 @@ class TestSwapStrategies(TestCase):
         self.mapped_paulis = [tuple(pauli) for pauli in data["paulis"]]
         self.mapped_graph = build_max_cut_graph(self.mapped_paulis)
 
-        self.sat_mapping = {
-            int(key): value for key, value in data["SAT mapping"].items()
-        }
+        self.sat_mapping = {int(key): value for key, value in data["SAT mapping"].items()}
         self.min_k = data["min swap layers"]
-        self.swap_strategy = SwapStrategy.from_line(
-            list(range(len(self.original_graph.nodes)))
-        )
+        self.swap_strategy = SwapStrategy.from_line(list(range(len(self.original_graph.nodes))))
         self.basic_graphs = [nx.path_graph(5), nx.cycle_graph(7)]
 
     def test_find_initial_mappings(self):
@@ -166,9 +160,7 @@ class TestSwapStrategies(TestCase):
         self.assertIsInstance(min_layers, int)
 
         # Verify the remapped operator still has parametric coefficients
-        self.assertTrue(
-            any(isinstance(coeff, ParameterExpression) for coeff in remapped_op.coeffs)
-        )
+        self.assertTrue(any(isinstance(coeff, ParameterExpression) for coeff in remapped_op.coeffs))
 
         # Verify all original parameters are present in remapped operator
         original_params = set(parametric_hamiltonian.parameters)

--- a/test/test_sat_mapping.py
+++ b/test/test_sat_mapping.py
@@ -136,7 +136,7 @@ class TestSwapStrategies(TestCase):
         c_1 = Parameter("c_1")
         c_2 = Parameter("c_2")
 
-        # Create parametric SparsePauliOp using direct constructor (not from_list) to ensure parameters are preserved
+        # Create parametric SparsePauliOp to ensure parameters are preserved
         pauli_strings = ["ZZII", "IZZI", "IIZZ"]
         coeffs = [c_0, c_1, c_2]
         parametric_hamiltonian = SparsePauliOp(pauli_strings, coeffs)

--- a/test/test_sat_mapping.py
+++ b/test/test_sat_mapping.py
@@ -1,15 +1,18 @@
 """Tests for SAT Mapping Utils"""
 
-from unittest import TestCase
 import json
 import os
-import networkx as nx
+from unittest import TestCase
 
+import networkx as nx
+from qiskit.circuit import Parameter
+from qiskit.circuit.parameterexpression import ParameterExpression
+from qiskit.quantum_info import SparsePauliOp
 from qiskit.transpiler import CouplingMap
 from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import SwapStrategy
 
-from qopt_best_practices.utils import build_max_cut_graph, build_max_cut_paulis
 from qopt_best_practices.sat_mapping import SATMapper
+from qopt_best_practices.utils import build_max_cut_graph, build_max_cut_paulis
 
 
 class TestSwapStrategies(TestCase):
@@ -19,7 +22,9 @@ class TestSwapStrategies(TestCase):
         super().setUp()
 
         # load data
-        graph_file = os.path.join(os.path.dirname(__file__), "data/graph_2layers_0seed.json")
+        graph_file = os.path.join(
+            os.path.dirname(__file__), "data/graph_2layers_0seed.json"
+        )
 
         with open(graph_file, "r") as file:
             data = json.load(file)
@@ -30,9 +35,13 @@ class TestSwapStrategies(TestCase):
         self.mapped_paulis = [tuple(pauli) for pauli in data["paulis"]]
         self.mapped_graph = build_max_cut_graph(self.mapped_paulis)
 
-        self.sat_mapping = {int(key): value for key, value in data["SAT mapping"].items()}
+        self.sat_mapping = {
+            int(key): value for key, value in data["SAT mapping"].items()
+        }
         self.min_k = data["min swap layers"]
-        self.swap_strategy = SwapStrategy.from_line(list(range(len(self.original_graph.nodes))))
+        self.swap_strategy = SwapStrategy.from_line(
+            list(range(len(self.original_graph.nodes)))
+        )
         self.basic_graphs = [nx.path_graph(5), nx.cycle_graph(7)]
 
     def test_find_initial_mappings(self):
@@ -118,3 +127,132 @@ class TestSwapStrategies(TestCase):
         self.assertIsNone(remapped_g)
         self.assertIsNone(edge_map)
         self.assertIsNone(min_sat_layers)
+
+    def test_parametric_hamiltonian(self):
+        """Test that SATMapper preserves parametric Hamiltonians correctly.
+
+        When a parametric cost Hamiltonian (with Parameter objects as coefficients)
+        is passed to remap_graph_with_sat, the parameters are preserved in the
+        remapped operator with the correct qubit mapping.
+        """
+        # Create a simple parametric Hamiltonian with Parameter weights
+        # H = c_0 * ZZ_01 + c_1 * ZZ_12 + c_2 * ZZ_23
+        c_0 = Parameter("c_0")
+        c_1 = Parameter("c_1")
+        c_2 = Parameter("c_2")
+
+        # Create parametric SparsePauliOp using direct constructor (not from_list)
+        pauli_strings = ["ZZII", "IZZI", "IIZZ"]
+        coeffs = [c_0, c_1, c_2]
+        parametric_hamiltonian = SparsePauliOp(pauli_strings, coeffs)
+
+        # Create a swap strategy for 4 qubits
+        swap_strategy = SwapStrategy.from_line([0, 1, 2, 3])
+
+        mapper = SATMapper()
+
+        # SATMapper should handle parametric Hamiltonians and preserve parameters
+        remapped_op, edge_map, min_layers = mapper.remap_graph_with_sat(
+            parametric_hamiltonian, swap_strategy
+        )
+
+        # Verify results - the mapping should succeed
+        self.assertIsNotNone(remapped_op)
+        self.assertIsNotNone(edge_map)
+        self.assertIsNotNone(min_layers)
+        self.assertIsInstance(remapped_op, SparsePauliOp)
+        self.assertIsInstance(edge_map, dict)
+        self.assertIsInstance(min_layers, int)
+
+        # Verify the remapped operator still has parametric coefficients
+        self.assertTrue(
+            any(isinstance(coeff, ParameterExpression) for coeff in remapped_op.coeffs)
+        )
+
+        # Verify all original parameters are present in remapped operator
+        original_params = set(parametric_hamiltonian.parameters)
+        remapped_params = set(remapped_op.parameters)
+        self.assertEqual(original_params, remapped_params)
+
+    def test_non_parametric_operator(self):
+        """Test SATMapper with non-parametric SparsePauliOp.
+
+        Verifies that the new parametric support doesn't break existing
+        functionality for numeric (non-parametric) operators.
+        """
+        # Create non-parametric Hamiltonian with numeric weights
+        pauli_strings = ["ZZII", "IZZI", "IIZZ"]
+        coeffs = [1.5, 2.0, 0.5]  # Different weights to verify preservation
+        numeric_hamiltonian = SparsePauliOp(pauli_strings, coeffs)
+
+        # Create swap strategy
+        swap_strategy = SwapStrategy.from_line([0, 1, 2, 3])
+
+        mapper = SATMapper()
+
+        # Apply SAT mapping
+        remapped_op, edge_map, min_layers = mapper.remap_graph_with_sat(
+            numeric_hamiltonian, swap_strategy
+        )
+
+        # Verify results
+        self.assertIsNotNone(remapped_op)
+        self.assertIsNotNone(edge_map)
+        self.assertIsNotNone(min_layers)
+        self.assertIsInstance(remapped_op, SparsePauliOp)
+        self.assertIsInstance(edge_map, dict)
+        self.assertIsInstance(min_layers, int)
+
+        # Verify no parameters in output (all numeric)
+        self.assertEqual(len(remapped_op.parameters), 0)
+
+        # Verify coefficients are preserved (not all 1.0)
+        coeffs_list = [abs(c) for c in remapped_op.coeffs]
+        self.assertEqual({1.5, 2.0, 0.5}, set(coeffs_list))
+
+    def test_parametric_hamiltonian_with_numeric_fallback(self):
+        """Test SATMapper with parametric Hamiltonian using numeric values.
+
+        This test verifies that if we bind parameters to numeric values first,
+        the SAT mapping works correctly.
+        """
+        # Create parametric Hamiltonian
+        c_0 = Parameter("c_0")
+        c_1 = Parameter("c_1")
+        c_2 = Parameter("c_2")
+
+        pauli_strings = ["ZZII", "IZZI", "IIZZ"]
+        coeffs = [c_0, c_1, c_2]
+        parametric_hamiltonian = SparsePauliOp(pauli_strings, coeffs)
+
+        # Bind parameters to numeric values
+        param_dict = {c_0: 1.0, c_1: 1.0, c_2: 1.0}
+        numeric_hamiltonian = parametric_hamiltonian.assign_parameters(param_dict)
+
+        # Verify numeric values before mapping
+        coeffs_before = [abs(c) for c in numeric_hamiltonian.coeffs]
+        self.assertEqual({1.0}, set(coeffs_before))
+        self.assertEqual(len(numeric_hamiltonian.parameters), 0)
+
+        # Create swap strategy
+        swap_strategy = SwapStrategy.from_line([0, 1, 2, 3])
+
+        mapper = SATMapper()
+
+        # This should work with numeric values
+        remapped_op, edge_map, min_layers = mapper.remap_graph_with_sat(
+            numeric_hamiltonian, swap_strategy
+        )
+
+        # Verify results
+        self.assertIsNotNone(remapped_op)
+        self.assertIsNotNone(edge_map)
+        self.assertIsNotNone(min_layers)
+        self.assertIsInstance(remapped_op, SparsePauliOp)
+        self.assertIsInstance(edge_map, dict)
+        self.assertIsInstance(min_layers, int)
+
+        # Verify numeric values after mapping are preserved
+        coeffs_after = [abs(c) for c in remapped_op.coeffs]
+        self.assertEqual({1.0}, set(coeffs_after))
+        self.assertEqual(len(remapped_op.parameters), 0)

--- a/test/test_sat_mapping.py
+++ b/test/test_sat_mapping.py
@@ -22,7 +22,9 @@ class TestSwapStrategies(TestCase):
         super().setUp()
 
         # load data
-        graph_file = os.path.join(os.path.dirname(__file__), "data/graph_2layers_0seed.json")
+        graph_file = os.path.join(
+            os.path.dirname(__file__), "data/graph_2layers_0seed.json"
+        )
 
         with open(graph_file, "r") as file:
             data = json.load(file)
@@ -33,9 +35,13 @@ class TestSwapStrategies(TestCase):
         self.mapped_paulis = [tuple(pauli) for pauli in data["paulis"]]
         self.mapped_graph = build_max_cut_graph(self.mapped_paulis)
 
-        self.sat_mapping = {int(key): value for key, value in data["SAT mapping"].items()}
+        self.sat_mapping = {
+            int(key): value for key, value in data["SAT mapping"].items()
+        }
         self.min_k = data["min swap layers"]
-        self.swap_strategy = SwapStrategy.from_line(list(range(len(self.original_graph.nodes))))
+        self.swap_strategy = SwapStrategy.from_line(
+            list(range(len(self.original_graph.nodes)))
+        )
         self.basic_graphs = [nx.path_graph(5), nx.cycle_graph(7)]
 
     def test_find_initial_mappings(self):
@@ -160,7 +166,9 @@ class TestSwapStrategies(TestCase):
         self.assertIsInstance(min_layers, int)
 
         # Verify the remapped operator still has parametric coefficients
-        self.assertTrue(any(isinstance(coeff, ParameterExpression) for coeff in remapped_op.coeffs))
+        self.assertTrue(
+            any(isinstance(coeff, ParameterExpression) for coeff in remapped_op.coeffs)
+        )
 
         # Verify all original parameters are present in remapped operator
         original_params = set(parametric_hamiltonian.parameters)
@@ -245,31 +253,3 @@ class TestSwapStrategies(TestCase):
         self.assertIsInstance(edge_map, dict)
         coeffs_after = [abs(c) for c in remapped_op.coeffs]
         self.assertEqual({1.0}, set(coeffs_after))
-
-    def test_remap_operator_large_qubits(self):
-        """Test remap_operator with large number of qubits to verify to_label() doesn't truncate."""
-        num_qubits = 50
-
-        # Create operator with ZZ terms on qubits 0-1 and 48-49
-        pauli_strings = ["ZZ" + "I" * 48, "I" * 48 + "ZZ"]
-        coeffs = [1.0, 2.0]
-        large_operator = SparsePauliOp(pauli_strings, coeffs)
-
-        # Remap qubits
-        qubit_map = {0: 10, 1: 11, 48: 20, 49: 21}
-        remapped_op = SATMapper.remap_operator(large_operator, qubit_map)
-
-        # Verify structure
-        self.assertEqual(remapped_op.num_qubits, num_qubits)
-        self.assertEqual(len(remapped_op), 2)
-
-        # Verify coefficients preserved
-        coeffs_list = [abs(c) for c in remapped_op.coeffs]
-        self.assertEqual({1.0, 2.0}, set(coeffs_list))
-
-        # Verify no truncation - each label should have exactly 2 Z's and correct length
-        labels = [pauli.to_label() for pauli in remapped_op.paulis]
-        for label in labels:
-            self.assertEqual(label.count("Z"), 2)
-            self.assertEqual(len(label), num_qubits)
-        self.assertEqual(len(remapped_op.parameters), 0)

--- a/test/test_sat_mapping.py
+++ b/test/test_sat_mapping.py
@@ -22,7 +22,9 @@ class TestSwapStrategies(TestCase):
         super().setUp()
 
         # load data
-        graph_file = os.path.join(os.path.dirname(__file__), "data/graph_2layers_0seed.json")
+        graph_file = os.path.join(
+            os.path.dirname(__file__), "data/graph_2layers_0seed.json"
+        )
 
         with open(graph_file, "r") as file:
             data = json.load(file)
@@ -33,9 +35,13 @@ class TestSwapStrategies(TestCase):
         self.mapped_paulis = [tuple(pauli) for pauli in data["paulis"]]
         self.mapped_graph = build_max_cut_graph(self.mapped_paulis)
 
-        self.sat_mapping = {int(key): value for key, value in data["SAT mapping"].items()}
+        self.sat_mapping = {
+            int(key): value for key, value in data["SAT mapping"].items()
+        }
         self.min_k = data["min swap layers"]
-        self.swap_strategy = SwapStrategy.from_line(list(range(len(self.original_graph.nodes))))
+        self.swap_strategy = SwapStrategy.from_line(
+            list(range(len(self.original_graph.nodes)))
+        )
         self.basic_graphs = [nx.path_graph(5), nx.cycle_graph(7)]
 
     def test_find_initial_mappings(self):
@@ -160,7 +166,9 @@ class TestSwapStrategies(TestCase):
         self.assertIsInstance(min_layers, int)
 
         # Verify the remapped operator still has parametric coefficients
-        self.assertTrue(any(isinstance(coeff, ParameterExpression) for coeff in remapped_op.coeffs))
+        self.assertTrue(
+            any(isinstance(coeff, ParameterExpression) for coeff in remapped_op.coeffs)
+        )
 
         # Verify all original parameters are present in remapped operator
         original_params = set(parametric_hamiltonian.parameters)
@@ -243,9 +251,33 @@ class TestSwapStrategies(TestCase):
         self.assertIsNotNone(min_layers)
         self.assertIsInstance(remapped_op, SparsePauliOp)
         self.assertIsInstance(edge_map, dict)
-        self.assertIsInstance(min_layers, int)
-
-        # Verify numeric values after mapping are preserved
         coeffs_after = [abs(c) for c in remapped_op.coeffs]
         self.assertEqual({1.0}, set(coeffs_after))
+
+    def test_remap_operator_large_qubits(self):
+        """Test remap_operator with large number of qubits to verify to_label() doesn't truncate."""
+        num_qubits = 50
+
+        # Create operator with ZZ terms on qubits 0-1 and 48-49
+        pauli_strings = ["ZZ" + "I" * 48, "I" * 48 + "ZZ"]
+        coeffs = [1.0, 2.0]
+        large_operator = SparsePauliOp(pauli_strings, coeffs)
+
+        # Remap qubits
+        qubit_map = {0: 10, 1: 11, 48: 20, 49: 21}
+        remapped_op = SATMapper.remap_operator(large_operator, qubit_map)
+
+        # Verify structure
+        self.assertEqual(remapped_op.num_qubits, num_qubits)
+        self.assertEqual(len(remapped_op), 2)
+
+        # Verify coefficients preserved
+        coeffs_list = [abs(c) for c in remapped_op.coeffs]
+        self.assertEqual({1.0, 2.0}, set(coeffs_list))
+
+        # Verify no truncation - each label should have exactly 2 Z's and correct length
+        labels = [pauli.to_label() for pauli in remapped_op.paulis]
+        for label in labels:
+            self.assertEqual(label.count("Z"), 2)
+            self.assertEqual(len(label), num_qubits)
         self.assertEqual(len(remapped_op.parameters), 0)

--- a/test/test_sat_mapping.py
+++ b/test/test_sat_mapping.py
@@ -22,9 +22,7 @@ class TestSwapStrategies(TestCase):
         super().setUp()
 
         # load data
-        graph_file = os.path.join(
-            os.path.dirname(__file__), "data/graph_2layers_0seed.json"
-        )
+        graph_file = os.path.join(os.path.dirname(__file__), "data/graph_2layers_0seed.json")
 
         with open(graph_file, "r") as file:
             data = json.load(file)
@@ -35,13 +33,9 @@ class TestSwapStrategies(TestCase):
         self.mapped_paulis = [tuple(pauli) for pauli in data["paulis"]]
         self.mapped_graph = build_max_cut_graph(self.mapped_paulis)
 
-        self.sat_mapping = {
-            int(key): value for key, value in data["SAT mapping"].items()
-        }
+        self.sat_mapping = {int(key): value for key, value in data["SAT mapping"].items()}
         self.min_k = data["min swap layers"]
-        self.swap_strategy = SwapStrategy.from_line(
-            list(range(len(self.original_graph.nodes)))
-        )
+        self.swap_strategy = SwapStrategy.from_line(list(range(len(self.original_graph.nodes))))
         self.basic_graphs = [nx.path_graph(5), nx.cycle_graph(7)]
 
     def test_find_initial_mappings(self):
@@ -131,9 +125,10 @@ class TestSwapStrategies(TestCase):
     def test_parametric_hamiltonian(self):
         """Test that SATMapper preserves parametric Hamiltonians correctly.
 
-        When a parametric cost Hamiltonian (with Parameter objects as coefficients)
-        is passed to remap_graph_with_sat, the parameters are preserved in the
-        remapped operator with the correct qubit mapping.
+        Verifies that when a parametric cost Hamiltonian (with Parameter objects as
+        coefficients) is passed to remap_graph_with_sat, the parameters are preserved
+        in the remapped operator with the correct qubit mapping. This is critical for
+        multi-objective workflows where parameters are bound later during optimization.
         """
         # Create a simple parametric Hamiltonian with Parameter weights
         # H = c_0 * ZZ_01 + c_1 * ZZ_12 + c_2 * ZZ_23
@@ -141,7 +136,7 @@ class TestSwapStrategies(TestCase):
         c_1 = Parameter("c_1")
         c_2 = Parameter("c_2")
 
-        # Create parametric SparsePauliOp using direct constructor (not from_list)
+        # Create parametric SparsePauliOp using direct constructor (not from_list) to ensure parameters are preserved
         pauli_strings = ["ZZII", "IZZI", "IIZZ"]
         coeffs = [c_0, c_1, c_2]
         parametric_hamiltonian = SparsePauliOp(pauli_strings, coeffs)
@@ -165,9 +160,7 @@ class TestSwapStrategies(TestCase):
         self.assertIsInstance(min_layers, int)
 
         # Verify the remapped operator still has parametric coefficients
-        self.assertTrue(
-            any(isinstance(coeff, ParameterExpression) for coeff in remapped_op.coeffs)
-        )
+        self.assertTrue(any(isinstance(coeff, ParameterExpression) for coeff in remapped_op.coeffs))
 
         # Verify all original parameters are present in remapped operator
         original_params = set(parametric_hamiltonian.parameters)


### PR DESCRIPTION

### Summary
This PR adds support for parametric Hamiltonians (with Parameter objects as coefficients) to the SAT mapper. Previously, the SAT mapper would lose parametric coefficients when remapping operators. Now, parameters are preserved throughout the remapping process, enabling their use in multi-objective optimization workflows where parameters are bound later.


### Details and comments

New Feature: Parametric Hamiltonian Support

New method: remap_operator (sat_mapper.py, lines 214-241)
    Directly remaps qubits in a SparsePauliOp while preserving all coefficients, including parametric ones
    Uses SparsePauliOp constructor (not from_list) to maintain ParameterExpression objects
    Maps qubit indices according to the SAT-determined mapping

Enhanced: remap_graph_with_sat (sat_mapper.py, lines 178-221)
    Now accepts both nx.Graph and SparsePauliOp as input
    When SparsePauliOp is provided:
    Converts to graph for structure analysis only
    Remaps the original operator directly using remap_operator
    Preserves all parametric coefficients in the output

Enhanced: op2graph (sat_mapper.py, lines 267-298)
    Now handles parametric coefficients by converting them to weight 1.0 for graph structure analysis
    Only connectivity pattern matters for SAT mapping, not actual weights
    Raises ValueError for non-quadratic operators
