### PR TITLE
Parametric hamiltonian support to annotated prepare cost layer

### DIFF
--- a/qopt_best_practices/transpilation/annotated_transpilation_passes.py
+++ b/qopt_best_practices/transpilation/annotated_transpilation_passes.py
@@ -67,11 +67,11 @@ def _group_by_parametric_signature(
             free_params = param.parameters
 
             # Check if there are any parameters beyond the standard QAOA layer parameters
-            # Suggested:
             # QAOA layer parameters (γ[i], β[i]) vs custom coefficients (c_0, c_1, etc.)
-
             custom_params = {
-                p for p in free_params if not (p.name.startswith("γ[") or p.name.startswith("β["))
+                p
+                for p in free_params
+                if not (p.name.startswith("γ[") or p.name.startswith("β["))
             }
 
             if custom_params:
@@ -153,7 +153,9 @@ class AnnotatedPrepareCostLayer(TransformationPass):
                     if "numeric" in param_groups:
                         numeric_nodes = param_groups["numeric"]
                         commuting_block = Commuting2qBlock(numeric_nodes)
-                        box_dag.replace_block_with_op(numeric_nodes, commuting_block, wire_order)
+                        box_dag.replace_block_with_op(
+                            numeric_nodes, commuting_block, wire_order
+                        )
 
                     for z_node in rz_gates:
                         box_dag.apply_operation_back(
@@ -214,7 +216,9 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
         if self._swap_strategy is None:
             swap_strategy = self.property_set["swap_strategy"]
             if swap_strategy is None:
-                raise TranspilerError("No swap strategy given at init or in the property set.")
+                raise TranspilerError(
+                    "No swap strategy given at init or in the property set."
+                )
         else:
             swap_strategy = self._swap_strategy
 
@@ -223,7 +227,9 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
                 f"{self.__class__.__name__} runs on circuits with one quantum register."
             )
         if len(dag.qubits) != next(iter(dag.qregs.values())).size:
-            raise TranspilerError("Circuit has qubits not contained in the qubit register.")
+            raise TranspilerError(
+                "Circuit has qubits not contained in the qubit register."
+            )
 
         if not dag.cregs:
             for qreg in dag.qregs.values():
@@ -240,10 +246,14 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
                     }
                     self.property_set["original_layout"] = Layout(input_qubit_mapping)
                     if self.property_set["original_qubit_indices"] is None:
-                        self.property_set["original_qubit_indices"] = input_qubit_mapping
+                        self.property_set["original_qubit_indices"] = (
+                            input_qubit_mapping
+                        )
 
                     new_dag = box_dag.copy_empty_like()
-                    current_layout = Layout.generate_trivial_layout(*box_dag.qregs.values())
+                    current_layout = Layout.generate_trivial_layout(
+                        *box_dag.qregs.values()
+                    )
                     # Used to keep track of nodes that do not decompose using swap strategies.
                     accumulator = new_dag.copy_empty_like()
 
@@ -287,7 +297,9 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
                                 if int(node.op.annotations[0].payload) % 2 == 1
                                 else dag.qubits[cidx]
                             )
-                            dag.apply_operation_back(Measure(), [qubit], [dag.clbits[cidx]])
+                            dag.apply_operation_back(
+                                Measure(), [qubit], [dag.clbits[cidx]]
+                            )
 
         return dag
 
@@ -318,7 +330,9 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
         # Re-initialize the node accumulator
         return new_dag.copy_empty_like()
 
-    def _position_in_cmap(self, dag: DAGCircuit, j: int, k: int, layout: Layout) -> tuple[int, ...]:
+    def _position_in_cmap(
+        self, dag: DAGCircuit, j: int, k: int, layout: Layout
+    ) -> tuple[int, ...]:
         """A helper function to track the movement of virtual qubits through the swaps.
 
         Args:
@@ -440,7 +454,9 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
 
             if i < max_distance:
                 for swap in swap_strategy.swap_layer(i):
-                    (j, k) = [trivial_layout.get_physical_bits()[vertex] for vertex in swap]
+                    (j, k) = [
+                        trivial_layout.get_physical_bits()[vertex] for vertex in swap
+                    ]
                     dag_with_swap.apply_operation_back(SwapGate(), [j, k])
                     current_layout.swap(j, k)
 
@@ -472,7 +488,9 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
 
         return gate_layers
 
-    def _check_edges(self, dag: DAGCircuit, node: DAGOpNode, swap_strategy: SwapStrategy):
+    def _check_edges(
+        self, dag: DAGCircuit, node: DAGOpNode, swap_strategy: SwapStrategy
+    ):
         """Check if the swap strategy can create the required connectivity.
 
         Args:
@@ -546,7 +564,9 @@ class AnnotatedSwapToFinalMapping(TransformationPass):
                         final_params
                     )
                     new_dag = circuit_to_dag(
-                        new_circuit.reverse_ops() if layer_index % 2 == 0 else new_circuit
+                        new_circuit.reverse_ops()
+                        if layer_index % 2 == 0
+                        else new_circuit
                     )
                     node.op.params[0] = dag_to_circuit(new_dag)
                 else:
@@ -572,7 +592,9 @@ class AnnotatedSwapToFinalMapping(TransformationPass):
                     node.op.params[0] = dag_to_circuit(new_dag)
 
         # Permute final measurements
-        measure_nodes = [node for node in dag.op_nodes() if isinstance(node.op, Measure)]
+        measure_nodes = [
+            node for node in dag.op_nodes() if isinstance(node.op, Measure)
+        ]
 
         if len(measure_nodes) > 0:
             for node in measure_nodes:

--- a/qopt_best_practices/transpilation/annotated_transpilation_passes.py
+++ b/qopt_best_practices/transpilation/annotated_transpilation_passes.py
@@ -69,9 +69,7 @@ def _group_by_parametric_signature(
             # Check if there are any parameters beyond the standard QAOA layer parameters
             # QAOA layer parameters (γ[i], β[i]) vs custom coefficients (c_0, c_1, etc.)
             custom_params = {
-                p
-                for p in free_params
-                if not (p.name.startswith("γ[") or p.name.startswith("β["))
+                p for p in free_params if not (p.name.startswith("γ[") or p.name.startswith("β["))
             }
 
             if custom_params:
@@ -153,9 +151,7 @@ class AnnotatedPrepareCostLayer(TransformationPass):
                     if "numeric" in param_groups:
                         numeric_nodes = param_groups["numeric"]
                         commuting_block = Commuting2qBlock(numeric_nodes)
-                        box_dag.replace_block_with_op(
-                            numeric_nodes, commuting_block, wire_order
-                        )
+                        box_dag.replace_block_with_op(numeric_nodes, commuting_block, wire_order)
 
                     for z_node in rz_gates:
                         box_dag.apply_operation_back(
@@ -216,9 +212,7 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
         if self._swap_strategy is None:
             swap_strategy = self.property_set["swap_strategy"]
             if swap_strategy is None:
-                raise TranspilerError(
-                    "No swap strategy given at init or in the property set."
-                )
+                raise TranspilerError("No swap strategy given at init or in the property set.")
         else:
             swap_strategy = self._swap_strategy
 
@@ -227,9 +221,7 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
                 f"{self.__class__.__name__} runs on circuits with one quantum register."
             )
         if len(dag.qubits) != next(iter(dag.qregs.values())).size:
-            raise TranspilerError(
-                "Circuit has qubits not contained in the qubit register."
-            )
+            raise TranspilerError("Circuit has qubits not contained in the qubit register.")
 
         if not dag.cregs:
             for qreg in dag.qregs.values():
@@ -246,14 +238,10 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
                     }
                     self.property_set["original_layout"] = Layout(input_qubit_mapping)
                     if self.property_set["original_qubit_indices"] is None:
-                        self.property_set["original_qubit_indices"] = (
-                            input_qubit_mapping
-                        )
+                        self.property_set["original_qubit_indices"] = input_qubit_mapping
 
                     new_dag = box_dag.copy_empty_like()
-                    current_layout = Layout.generate_trivial_layout(
-                        *box_dag.qregs.values()
-                    )
+                    current_layout = Layout.generate_trivial_layout(*box_dag.qregs.values())
                     # Used to keep track of nodes that do not decompose using swap strategies.
                     accumulator = new_dag.copy_empty_like()
 
@@ -297,9 +285,7 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
                                 if int(node.op.annotations[0].payload) % 2 == 1
                                 else dag.qubits[cidx]
                             )
-                            dag.apply_operation_back(
-                                Measure(), [qubit], [dag.clbits[cidx]]
-                            )
+                            dag.apply_operation_back(Measure(), [qubit], [dag.clbits[cidx]])
 
         return dag
 
@@ -330,9 +316,7 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
         # Re-initialize the node accumulator
         return new_dag.copy_empty_like()
 
-    def _position_in_cmap(
-        self, dag: DAGCircuit, j: int, k: int, layout: Layout
-    ) -> tuple[int, ...]:
+    def _position_in_cmap(self, dag: DAGCircuit, j: int, k: int, layout: Layout) -> tuple[int, ...]:
         """A helper function to track the movement of virtual qubits through the swaps.
 
         Args:
@@ -454,9 +438,7 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
 
             if i < max_distance:
                 for swap in swap_strategy.swap_layer(i):
-                    (j, k) = [
-                        trivial_layout.get_physical_bits()[vertex] for vertex in swap
-                    ]
+                    (j, k) = [trivial_layout.get_physical_bits()[vertex] for vertex in swap]
                     dag_with_swap.apply_operation_back(SwapGate(), [j, k])
                     current_layout.swap(j, k)
 
@@ -488,9 +470,7 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
 
         return gate_layers
 
-    def _check_edges(
-        self, dag: DAGCircuit, node: DAGOpNode, swap_strategy: SwapStrategy
-    ):
+    def _check_edges(self, dag: DAGCircuit, node: DAGOpNode, swap_strategy: SwapStrategy):
         """Check if the swap strategy can create the required connectivity.
 
         Args:
@@ -564,9 +544,7 @@ class AnnotatedSwapToFinalMapping(TransformationPass):
                         final_params
                     )
                     new_dag = circuit_to_dag(
-                        new_circuit.reverse_ops()
-                        if layer_index % 2 == 0
-                        else new_circuit
+                        new_circuit.reverse_ops() if layer_index % 2 == 0 else new_circuit
                     )
                     node.op.params[0] = dag_to_circuit(new_dag)
                 else:
@@ -592,9 +570,7 @@ class AnnotatedSwapToFinalMapping(TransformationPass):
                     node.op.params[0] = dag_to_circuit(new_dag)
 
         # Permute final measurements
-        measure_nodes = [
-            node for node in dag.op_nodes() if isinstance(node.op, Measure)
-        ]
+        measure_nodes = [node for node in dag.op_nodes() if isinstance(node.op, Measure)]
 
         if len(measure_nodes) > 0:
             for node in measure_nodes:

--- a/qopt_best_practices/transpilation/annotated_transpilation_passes.py
+++ b/qopt_best_practices/transpilation/annotated_transpilation_passes.py
@@ -71,9 +71,7 @@ def _group_by_parametric_signature(
             # QAOA layer parameters (γ[i], β[i]) vs custom coefficients (c_0, c_1, etc.)
 
             custom_params = {
-                p
-                for p in free_params
-                if not (p.name.startswith("γ[") or p.name.startswith("β["))
+                p for p in free_params if not (p.name.startswith("γ[") or p.name.startswith("β["))
             }
 
             if custom_params:
@@ -155,9 +153,7 @@ class AnnotatedPrepareCostLayer(TransformationPass):
                     if "numeric" in param_groups:
                         numeric_nodes = param_groups["numeric"]
                         commuting_block = Commuting2qBlock(numeric_nodes)
-                        box_dag.replace_block_with_op(
-                            numeric_nodes, commuting_block, wire_order
-                        )
+                        box_dag.replace_block_with_op(numeric_nodes, commuting_block, wire_order)
 
                     for z_node in rz_gates:
                         box_dag.apply_operation_back(
@@ -218,9 +214,7 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
         if self._swap_strategy is None:
             swap_strategy = self.property_set["swap_strategy"]
             if swap_strategy is None:
-                raise TranspilerError(
-                    "No swap strategy given at init or in the property set."
-                )
+                raise TranspilerError("No swap strategy given at init or in the property set.")
         else:
             swap_strategy = self._swap_strategy
 
@@ -229,9 +223,7 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
                 f"{self.__class__.__name__} runs on circuits with one quantum register."
             )
         if len(dag.qubits) != next(iter(dag.qregs.values())).size:
-            raise TranspilerError(
-                "Circuit has qubits not contained in the qubit register."
-            )
+            raise TranspilerError("Circuit has qubits not contained in the qubit register.")
 
         if not dag.cregs:
             for qreg in dag.qregs.values():
@@ -248,14 +240,10 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
                     }
                     self.property_set["original_layout"] = Layout(input_qubit_mapping)
                     if self.property_set["original_qubit_indices"] is None:
-                        self.property_set["original_qubit_indices"] = (
-                            input_qubit_mapping
-                        )
+                        self.property_set["original_qubit_indices"] = input_qubit_mapping
 
                     new_dag = box_dag.copy_empty_like()
-                    current_layout = Layout.generate_trivial_layout(
-                        *box_dag.qregs.values()
-                    )
+                    current_layout = Layout.generate_trivial_layout(*box_dag.qregs.values())
                     # Used to keep track of nodes that do not decompose using swap strategies.
                     accumulator = new_dag.copy_empty_like()
 
@@ -299,9 +287,7 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
                                 if int(node.op.annotations[0].payload) % 2 == 1
                                 else dag.qubits[cidx]
                             )
-                            dag.apply_operation_back(
-                                Measure(), [qubit], [dag.clbits[cidx]]
-                            )
+                            dag.apply_operation_back(Measure(), [qubit], [dag.clbits[cidx]])
 
         return dag
 
@@ -332,9 +318,7 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
         # Re-initialize the node accumulator
         return new_dag.copy_empty_like()
 
-    def _position_in_cmap(
-        self, dag: DAGCircuit, j: int, k: int, layout: Layout
-    ) -> tuple[int, ...]:
+    def _position_in_cmap(self, dag: DAGCircuit, j: int, k: int, layout: Layout) -> tuple[int, ...]:
         """A helper function to track the movement of virtual qubits through the swaps.
 
         Args:
@@ -456,9 +440,7 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
 
             if i < max_distance:
                 for swap in swap_strategy.swap_layer(i):
-                    (j, k) = [
-                        trivial_layout.get_physical_bits()[vertex] for vertex in swap
-                    ]
+                    (j, k) = [trivial_layout.get_physical_bits()[vertex] for vertex in swap]
                     dag_with_swap.apply_operation_back(SwapGate(), [j, k])
                     current_layout.swap(j, k)
 
@@ -490,9 +472,7 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
 
         return gate_layers
 
-    def _check_edges(
-        self, dag: DAGCircuit, node: DAGOpNode, swap_strategy: SwapStrategy
-    ):
+    def _check_edges(self, dag: DAGCircuit, node: DAGOpNode, swap_strategy: SwapStrategy):
         """Check if the swap strategy can create the required connectivity.
 
         Args:
@@ -566,9 +546,7 @@ class AnnotatedSwapToFinalMapping(TransformationPass):
                         final_params
                     )
                     new_dag = circuit_to_dag(
-                        new_circuit.reverse_ops()
-                        if layer_index % 2 == 0
-                        else new_circuit
+                        new_circuit.reverse_ops() if layer_index % 2 == 0 else new_circuit
                     )
                     node.op.params[0] = dag_to_circuit(new_dag)
                 else:
@@ -594,9 +572,7 @@ class AnnotatedSwapToFinalMapping(TransformationPass):
                     node.op.params[0] = dag_to_circuit(new_dag)
 
         # Permute final measurements
-        measure_nodes = [
-            node for node in dag.op_nodes() if isinstance(node.op, Measure)
-        ]
+        measure_nodes = [node for node in dag.op_nodes() if isinstance(node.op, Measure)]
 
         if len(measure_nodes) > 0:
             for node in measure_nodes:

--- a/qopt_best_practices/transpilation/annotated_transpilation_passes.py
+++ b/qopt_best_practices/transpilation/annotated_transpilation_passes.py
@@ -67,8 +67,9 @@ def _group_by_parametric_signature(
             free_params = param.parameters
 
             # Check if there are any parameters beyond the standard QAOA layer parameters
-            # Standard QAOA parameters follow the pattern γ[i] or β[i] (hardcoded in annotated_qaoa_ansatz)
-            # Any other parameters are custom coefficients (e.g., c_0, c_1, weights, etc.)
+            # Suggested:
+            # QAOA layer parameters (γ[i], β[i]) vs custom coefficients (c_0, c_1, etc.)
+
             custom_params = {
                 p
                 for p in free_params

--- a/qopt_best_practices/transpilation/annotated_transpilation_passes.py
+++ b/qopt_best_practices/transpilation/annotated_transpilation_passes.py
@@ -1,25 +1,95 @@
 """Annotated QAOA transpilation passes"""
 
 from __future__ import annotations
+
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
-
-from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import (
-    SwapStrategy,
-)
-from qiskit.transpiler import TransformationPass
-from qiskit.transpiler.passes.routing.commuting_2q_gate_routing.commuting_2q_block import (
-    Commuting2qBlock,
-)
-from qiskit.circuit import Gate, Qubit
+from qiskit.circuit import ClassicalRegister, Gate, Qubit
+from qiskit.circuit.library import Measure, SwapGate
 from qiskit.circuit.library.standard_gates import get_standard_gate_name_mapping
+from qiskit.circuit.parameterexpression import ParameterExpression
+from qiskit.converters import circuit_to_dag, dag_to_circuit
+from qiskit.dagcircuit import DAGCircuit, DAGOutNode
+from qiskit.transpiler import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.passes import HighLevelSynthesis, InverseCancellation
-from qiskit.dagcircuit import DAGOutNode, DAGCircuit, DAGOpNode
-from qiskit.circuit import ClassicalRegister
-from qiskit.circuit.library import SwapGate, Measure
-from qiskit.converters import dag_to_circuit, circuit_to_dag
+from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import (
+    SwapStrategy,
+)
+from qiskit.transpiler.passes.routing.commuting_2q_gate_routing.commuting_2q_block import (
+    Commuting2qBlock,
+)
+
+if TYPE_CHECKING:
+    from qiskit.dagcircuit import DAGOpNode
+
+
+def _group_by_parametric_signature(
+    nodes: list[DAGOpNode],
+) -> dict[str, list[DAGOpNode]]:
+    """Group DAG nodes by their parametric signature.
+
+    Nodes with the same parametric expression structure are grouped together.
+    All numeric (non-parametric) nodes are grouped together to allow optimization.
+
+    This preserves parametric coefficients when gates operate on the same qubits
+    but have different parametric expressions that should remain independent.
+
+    The key distinction is between:
+    - Expressions with custom parameters (e.g., c_0*γ, c_1*γ) - kept separate
+    - Expressions with only QAOA layer parameters (e.g., 2.5*γ, 1.0*β) - grouped together
+
+    Args:
+        nodes: List of DAGOpNode objects with rzz gates
+
+    Returns:
+        Mapping from parametric signature (string) to list of nodes with that signature
+
+    Example:
+        Gates with c_0*γ, c_1*γ, c_2*γ will be in separate groups (different c_i),
+        while gates with 1.0*γ, 2.0*γ, 3.0*γ will be in one group (only numeric coefficients).
+
+    Note:
+        This function assumes QAOA parameters follow the standard naming convention
+        γ[i] and β[i] as defined in annotated_qaoa_ansatz(). Any other parameters
+        are treated as custom coefficients that must be preserved independently.
+    """
+    groups = defaultdict(list)
+
+    for node in nodes:
+        # Get the parameter (angle) of the rzz gate
+        param = node.op.params[0]
+
+        if isinstance(param, ParameterExpression):
+            # Get the free parameters in this expression
+            free_params = param.parameters
+
+            # Check if there are any parameters beyond the standard QAOA layer parameters
+            # Standard QAOA parameters follow the pattern γ[i] or β[i] (hardcoded in annotated_qaoa_ansatz)
+            # Any other parameters are custom coefficients (e.g., c_0, c_1, weights, etc.)
+            custom_params = {
+                p
+                for p in free_params
+                if not (p.name.startswith("γ[") or p.name.startswith("β["))
+            }
+
+            if custom_params:
+                # Has custom parameters (e.g., c_0, c_1, c_2) - use full expression as signature
+                # This keeps gates with different custom parameters separate
+                signature = str(param)
+            else:
+                # Only has QAOA layer parameters (γ, β) with numeric coefficients
+                # Group these together for optimization
+                signature = "numeric"
+        else:
+            # Pure numeric value (no parameters at all)
+            signature = "numeric"
+
+        groups[signature].append(node)
+
+    return groups
 
 
 class AnnotatedPrepareCostLayer(TransformationPass):
@@ -36,6 +106,12 @@ class AnnotatedPrepareCostLayer(TransformationPass):
     Note that high order terms (i.e. cubic and more) produce ladders of
     CX gates with a Rz rotation when using `qaoa_ansatz`. This pass currently
     does not support high order terms.
+
+    Parametric Circuits:
+        This pass preserves parametric coefficients by grouping rzz gates
+        according to their parametric signature. Gates with different parametric
+        expressions are kept in separate blocks to prevent unwanted merging,
+        while numeric gates can still be optimized together.
     """
 
     def run(self, dag):
@@ -64,7 +140,8 @@ class AnnotatedPrepareCostLayer(TransformationPass):
                                 f"Found {box_node.op.name} instead."
                             )
 
-                    commuting_block = Commuting2qBlock(commuting_nodes)
+                    # Group rzz gates by parametric signature to preserve parametric coefficients
+                    param_groups = _group_by_parametric_signature(commuting_nodes)
 
                     wire_order = {
                         wire: idx
@@ -72,7 +149,14 @@ class AnnotatedPrepareCostLayer(TransformationPass):
                         if wire not in box_dag.idle_wires()
                     }
 
-                    box_dag.replace_block_with_op(commuting_nodes, commuting_block, wire_order)
+                    # Only create Commuting2qBlock for numeric gates
+                    # Parametric gates are left as individual rzz gates to preserve parameters
+                    if "numeric" in param_groups:
+                        numeric_nodes = param_groups["numeric"]
+                        commuting_block = Commuting2qBlock(numeric_nodes)
+                        box_dag.replace_block_with_op(
+                            numeric_nodes, commuting_block, wire_order
+                        )
 
                     for z_node in rz_gates:
                         box_dag.apply_operation_back(
@@ -133,7 +217,9 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
         if self._swap_strategy is None:
             swap_strategy = self.property_set["swap_strategy"]
             if swap_strategy is None:
-                raise TranspilerError("No swap strategy given at init or in the property set.")
+                raise TranspilerError(
+                    "No swap strategy given at init or in the property set."
+                )
         else:
             swap_strategy = self._swap_strategy
 
@@ -142,7 +228,9 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
                 f"{self.__class__.__name__} runs on circuits with one quantum register."
             )
         if len(dag.qubits) != next(iter(dag.qregs.values())).size:
-            raise TranspilerError("Circuit has qubits not contained in the qubit register.")
+            raise TranspilerError(
+                "Circuit has qubits not contained in the qubit register."
+            )
 
         if not dag.cregs:
             for qreg in dag.qregs.values():
@@ -159,10 +247,14 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
                     }
                     self.property_set["original_layout"] = Layout(input_qubit_mapping)
                     if self.property_set["original_qubit_indices"] is None:
-                        self.property_set["original_qubit_indices"] = input_qubit_mapping
+                        self.property_set["original_qubit_indices"] = (
+                            input_qubit_mapping
+                        )
 
                     new_dag = box_dag.copy_empty_like()
-                    current_layout = Layout.generate_trivial_layout(*box_dag.qregs.values())
+                    current_layout = Layout.generate_trivial_layout(
+                        *box_dag.qregs.values()
+                    )
                     # Used to keep track of nodes that do not decompose using swap strategies.
                     accumulator = new_dag.copy_empty_like()
 
@@ -206,7 +298,9 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
                                 if int(node.op.annotations[0].payload) % 2 == 1
                                 else dag.qubits[cidx]
                             )
-                            dag.apply_operation_back(Measure(), [qubit], [dag.clbits[cidx]])
+                            dag.apply_operation_back(
+                                Measure(), [qubit], [dag.clbits[cidx]]
+                            )
 
         return dag
 
@@ -237,7 +331,9 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
         # Re-initialize the node accumulator
         return new_dag.copy_empty_like()
 
-    def _position_in_cmap(self, dag: DAGCircuit, j: int, k: int, layout: Layout) -> tuple[int, ...]:
+    def _position_in_cmap(
+        self, dag: DAGCircuit, j: int, k: int, layout: Layout
+    ) -> tuple[int, ...]:
         """A helper function to track the movement of virtual qubits through the swaps.
 
         Args:
@@ -294,7 +390,7 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
 
     @staticmethod
     def _greedy_build_sub_layers(
-        current_layer: dict[tuple[int, int], Gate]
+        current_layer: dict[tuple[int, int], Gate],
     ) -> list[dict[tuple[int, int], Gate]]:
         """The greedy method of building sub-layers of commuting gates."""
         sub_layers = []
@@ -317,7 +413,11 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
         return sub_layers
 
     def swap_decompose(
-        self, dag: DAGCircuit, node: DAGOpNode, current_layout: Layout, swap_strategy: SwapStrategy
+        self,
+        dag: DAGCircuit,
+        node: DAGOpNode,
+        current_layout: Layout,
+        swap_strategy: SwapStrategy,
     ) -> DAGCircuit:
         """Take an instance of :class:`.Commuting2qBlock` and map it to the coupling map.
 
@@ -355,21 +455,30 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
 
             if i < max_distance:
                 for swap in swap_strategy.swap_layer(i):
-                    (j, k) = [trivial_layout.get_physical_bits()[vertex] for vertex in swap]
+                    (j, k) = [
+                        trivial_layout.get_physical_bits()[vertex] for vertex in swap
+                    ]
                     dag_with_swap.apply_operation_back(SwapGate(), [j, k])
                     current_layout.swap(j, k)
 
         return dag_with_swap
 
     def _make_op_layers(
-        self, dag: DAGCircuit, op: Commuting2qBlock, layout: Layout, swap_strategy: SwapStrategy
+        self,
+        dag: DAGCircuit,
+        op: Commuting2qBlock,
+        layout: Layout,
+        swap_strategy: SwapStrategy,
     ) -> dict[int, dict[tuple, Gate]]:
         """Creates layers of two-qubit gates based on the distance in the swap strategy."""
 
         gate_layers: dict[int, dict[tuple, Gate]] = defaultdict(dict)
 
         for node in op.node_block:
-            edge = (dag.find_bit(node.qargs[0]).index, dag.find_bit(node.qargs[1]).index)
+            edge = (
+                dag.find_bit(node.qargs[0]).index,
+                dag.find_bit(node.qargs[1]).index,
+            )
 
             bit0 = layout.get_virtual_bits()[dag.qubits[edge[0]]]
             bit1 = layout.get_virtual_bits()[dag.qubits[edge[1]]]
@@ -380,7 +489,9 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
 
         return gate_layers
 
-    def _check_edges(self, dag: DAGCircuit, node: DAGOpNode, swap_strategy: SwapStrategy):
+    def _check_edges(
+        self, dag: DAGCircuit, node: DAGOpNode, swap_strategy: SwapStrategy
+    ):
         """Check if the swap strategy can create the required connectivity.
 
         Args:
@@ -394,7 +505,10 @@ class AnnotatedCommuting2qGateRouter(TransformationPass):
         required_edges = set()
 
         for sub_node in node.op:
-            edge = (dag.find_bit(sub_node.qargs[0]).index, dag.find_bit(sub_node.qargs[1]).index)
+            edge = (
+                dag.find_bit(sub_node.qargs[0]).index,
+                dag.find_bit(sub_node.qargs[1]).index,
+            )
             required_edges.add(edge)
 
         # Check that the swap strategy supports all required edges
@@ -451,7 +565,9 @@ class AnnotatedSwapToFinalMapping(TransformationPass):
                         final_params
                     )
                     new_dag = circuit_to_dag(
-                        new_circuit.reverse_ops() if layer_index % 2 == 0 else new_circuit
+                        new_circuit.reverse_ops()
+                        if layer_index % 2 == 0
+                        else new_circuit
                     )
                     node.op.params[0] = dag_to_circuit(new_dag)
                 else:
@@ -477,7 +593,9 @@ class AnnotatedSwapToFinalMapping(TransformationPass):
                     node.op.params[0] = dag_to_circuit(new_dag)
 
         # Permute final measurements
-        measure_nodes = [node for node in dag.op_nodes() if isinstance(node.op, Measure)]
+        measure_nodes = [
+            node for node in dag.op_nodes() if isinstance(node.op, Measure)
+        ]
 
         if len(measure_nodes) > 0:
             for node in measure_nodes:

--- a/test/test_annotated_transpilation.py
+++ b/test/test_annotated_transpilation.py
@@ -1,35 +1,37 @@
 """Unit tests for annotated transpilation pipeline"""
 
 import unittest
+
 import networkx as nx
 from networkx import barabasi_albert_graph
-
+from qiskit.circuit.library import CXGate, qaoa_ansatz
 from qiskit.primitives import StatevectorEstimator
+from qiskit.providers.fake_provider import GenericBackendV2
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.transpiler import Layout, PassManager
-from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
-from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import (
-    SwapStrategy,
-    Commuting2qGateRouter,
-)
-from qiskit.circuit.library import CXGate, qaoa_ansatz
 from qiskit.transpiler.passes import HighLevelSynthesis, InverseCancellation
-from qiskit.providers.fake_provider import GenericBackendV2
+from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import (
+    Commuting2qGateRouter,
+    SwapStrategy,
+)
+from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
 from qopt_best_practices.circuit_library import annotated_qaoa_ansatz
-from qopt_best_practices.utils import build_max_cut_paulis
-from qopt_best_practices.transpilation.cost_layer import get_cost_layer
-from qopt_best_practices.transpilation.prepare_cost_layer import PrepareCostLayer
-from qopt_best_practices.transpilation.swap_cancellation_pass import SwapToFinalMapping
-from qopt_best_practices.transpilation.qaoa_construction_pass import QAOAConstructionPass
 from qopt_best_practices.qubit_selection import BackendEvaluator
 from qopt_best_practices.transpilation import (
-    AnnotatedPrepareCostLayer,
     AnnotatedCommuting2qGateRouter,
+    AnnotatedPrepareCostLayer,
     AnnotatedSwapToFinalMapping,
     SynthesizeAndSimplifyCostLayer,
     UnrollBoxes,
 )
+from qopt_best_practices.transpilation.cost_layer import get_cost_layer
+from qopt_best_practices.transpilation.prepare_cost_layer import PrepareCostLayer
+from qopt_best_practices.transpilation.qaoa_construction_pass import (
+    QAOAConstructionPass,
+)
+from qopt_best_practices.transpilation.swap_cancellation_pass import SwapToFinalMapping
+from qopt_best_practices.utils import build_max_cut_paulis
 
 
 def get_problem_barabasi(n=4, m=3):
@@ -76,7 +78,12 @@ class TestAnnotatedTranspilation(unittest.TestCase):
             (1, 4, 2, [(0, 1, 1.0), (0, 2, 1.0), (1, 2, 1.0), (2, 3, 1.0)]),
             (2, 4, 2, [(0, 1, 1.0), (0, 2, 1.0), (1, 2, 1.0), (2, 3, 1.0)]),
             (3, 4, 2, [(0, 1, 1.0), (0, 2, 1.0), (1, 2, 1.0), (2, 3, 1.0)]),
-            (2, 5, 3, [(0, 1, 1.0), (0, 2, 1.0), (1, 2, 1.0), (2, 3, 1.0), (3, 4, 1.0)]),
+            (
+                2,
+                5,
+                3,
+                [(0, 1, 1.0), (0, 2, 1.0), (1, 2, 1.0), (2, 3, 1.0), (3, 4, 1.0)],
+            ),
             (
                 2,
                 7,
@@ -102,7 +109,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
     def _estimate(self, circuit, hamiltonian, param_values):
         circuit.remove_final_measurements()
         isa_hamiltonian = hamiltonian.apply_layout(circuit.layout)
-        result = self.estimator.run([(circuit, isa_hamiltonian, param_values)]).result()[0]
+        result = self.estimator.run(
+            [(circuit, isa_hamiltonian, param_values)]
+        ).result()[0]
         return list(result.data.values())
 
     def _assert_equivalence(self, expvals_1, expvals_2, circuit_1, circuit_2):
@@ -111,7 +120,13 @@ class TestAnnotatedTranspilation(unittest.TestCase):
             self.assertEqual(circuit_1.count_ops()[key], circuit_2.count_ops()[key])
 
     def _run_qopt_and_annot(  # pylint: disable=too-many-positional-arguments
-        self, cost_layer, hamiltonian, num_qaoa_layers, backend, initial_layout, optimized=False
+        self,
+        cost_layer,
+        hamiltonian,
+        num_qaoa_layers,
+        backend,
+        initial_layout,
+        optimized=False,
     ):
         """Run both the previous qopt pipeline and new annotated pipeline"""
 
@@ -146,7 +161,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         ]
         if optimized:
             annot_passes.append(
-                SynthesizeAndSimplifyCostLayer(basis_gates=["x", "cx", "sx", "rz", "id"])
+                SynthesizeAndSimplifyCostLayer(
+                    basis_gates=["x", "cx", "sx", "rz", "id"]
+                )
             )
         annot_passes.append(UnrollBoxes())
 
@@ -173,7 +190,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         swap_strategy, edge_coloring = self._get_swap_strategy(cost_layer)
 
         # Standard pipeline
-        standard_ansatz = qaoa_ansatz(hamiltonian, reps=num_qaoa_layers, mixer_operator=mixer_op)
+        standard_ansatz = qaoa_ansatz(
+            hamiltonian, reps=num_qaoa_layers, mixer_operator=mixer_op
+        )
         standard_pm = generate_preset_pass_manager(
             backend=backend, optimization_level=3, initial_layout=initial_layout
         )
@@ -191,7 +210,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         ]
         if optimized:
             annot_passes.append(
-                SynthesizeAndSimplifyCostLayer(basis_gates=["x", "cx", "sx", "rz", "id"])
+                SynthesizeAndSimplifyCostLayer(
+                    basis_gates=["x", "cx", "sx", "rz", "id"]
+                )
             )
         annot_passes.append(UnrollBoxes())
 
@@ -204,7 +225,13 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         return standard_transpiled, annot_transpiled
 
     def _run_comparison_qopt(  # pylint: disable=too-many-positional-arguments
-        self, hamiltonian, cost_layer, num_qaoa_layers, backend, initial_layout, optimized=False
+        self,
+        hamiltonian,
+        cost_layer,
+        num_qaoa_layers,
+        backend,
+        initial_layout,
+        optimized=False,
     ):
         """Run both transpilation pipelines and compare expectation values
         and number of final operations"""
@@ -215,7 +242,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         )
         eval_qopt = self._estimate(qopt_transpiled, hamiltonian, param_values)
         eval_annot = self._estimate(annot_transpiled, hamiltonian, param_values)
-        self._assert_equivalence(eval_annot, eval_qopt, annot_transpiled, qopt_transpiled)
+        self._assert_equivalence(
+            eval_annot, eval_qopt, annot_transpiled, qopt_transpiled
+        )
 
     def _run_comparison_standard(  # pylint: disable=too-many-positional-arguments
         self,
@@ -232,12 +261,20 @@ class TestAnnotatedTranspilation(unittest.TestCase):
 
         param_values = [5.11350346] * num_qaoa_layers + [5.52673212] * num_qaoa_layers
         standard_transpiled, annot_transpiled = self._run_standard_and_annot(
-            cost_layer, hamiltonian, mixer_op, num_qaoa_layers, backend, initial_layout, optimized
+            cost_layer,
+            hamiltonian,
+            mixer_op,
+            num_qaoa_layers,
+            backend,
+            initial_layout,
+            optimized,
         )
         eval_standard = self._estimate(standard_transpiled, hamiltonian, param_values)
         eval_annot = self._estimate(annot_transpiled, hamiltonian, param_values)
 
-        self._assert_equivalence(eval_annot, eval_standard, annot_transpiled, standard_transpiled)
+        self._assert_equivalence(
+            eval_annot, eval_standard, annot_transpiled, standard_transpiled
+        )
 
     def _run_all_cases(self, problem_fn, optimized=False):
         """Iterate over given test cases and run"""
@@ -255,7 +292,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
             with self.subTest(layers=layers, nodes=nodes, edges=edges):
                 hamiltonian, cost_layer, _ = get_problem_barabasi(n=nodes, m=edges)
                 backend, initial_layout = backend_and_layout_a(cost_layer)
-                self._run_comparison_qopt(hamiltonian, cost_layer, layers, backend, initial_layout)
+                self._run_comparison_qopt(
+                    hamiltonian, cost_layer, layers, backend, initial_layout
+                )
 
     def test_barabasi_albert_optimized(self):
         """Run comparison with barabasi albert graph and an additional synthesis/cancellation step."""
@@ -264,7 +303,12 @@ class TestAnnotatedTranspilation(unittest.TestCase):
                 hamiltonian, cost_layer, _ = get_problem_barabasi(n=nodes, m=edges)
                 backend, initial_layout = backend_and_layout_a(cost_layer)
                 self._run_comparison_qopt(
-                    hamiltonian, cost_layer, layers, backend, initial_layout, optimized=True
+                    hamiltonian,
+                    cost_layer,
+                    layers,
+                    backend,
+                    initial_layout,
+                    optimized=True,
                 )
 
     def test_maxcut_basic(self):
@@ -293,7 +337,13 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         mixer_op = SparsePauliOp.from_list([("IIX", 1), ("IXI", 2), ("XII", 3)])
 
         self._run_comparison_standard(
-            hamiltonian, cost_layer, mixer_op, 1, backend, initial_layout, optimized=False
+            hamiltonian,
+            cost_layer,
+            mixer_op,
+            1,
+            backend,
+            initial_layout,
+            optimized=False,
         )
 
     def test_standard_two_local_mixer(self):
@@ -306,7 +356,13 @@ class TestAnnotatedTranspilation(unittest.TestCase):
 
         with self.assertRaises(NotImplementedError):
             self._run_standard_and_annot(
-                cost_layer, hamiltonian, mixer_op, 3, backend, initial_layout, optimized=False
+                cost_layer,
+                hamiltonian,
+                mixer_op,
+                3,
+                backend,
+                initial_layout,
+                optimized=False,
             )
 
     def test_cost_op_single_rz(self):
@@ -333,7 +389,109 @@ class TestAnnotatedTranspilation(unittest.TestCase):
             if inst.operation.name == "box":
                 if "cost_layer" in inst.operation.annotations[0].namespace:
                     box_circ = inst.operation.params[0]
-                    self.assertEqual(box_circ.count_ops(), {"rz": 4, "commuting_2q_block": 1})
+                    self.assertEqual(
+                        box_circ.count_ops(), {"rz": 4, "commuting_2q_block": 1}
+                    )
+
+
+class TestAnnotatedPrepareCostLayerParametric(unittest.TestCase):
+    """Test AnnotatedPrepareCostLayer with parametric Hamiltonians."""
+
+    @staticmethod
+    def _build_hamiltonian_from_graphs(graphs, param_names=None):
+        """Build Hamiltonian from graphs with optional parametric coefficients.
+
+        Args:
+            graphs: List of NetworkX graphs with edge weights
+            param_names: Optional list of parameter names. If None, uses numeric coefficients.
+
+        Returns:
+            SparsePauliOp: The resulting Hamiltonian
+        """
+        from qiskit.circuit.parameter import Parameter
+
+        hamiltonians = []
+        for graph in graphs:
+            pauli_list = []
+            for u, v, data in graph.edges(data=True):
+                weight = data["weight"]
+                pauli_str = ["I"] * len(graph.nodes)
+                pauli_str[len(graph.nodes) - 1 - u] = "Z"
+                pauli_str[len(graph.nodes) - 1 - v] = "Z"
+                pauli_list.append(("".join(pauli_str), weight))
+            hamiltonians.append(SparsePauliOp.from_list(pauli_list))
+
+        if param_names is None:
+            # Numeric sum
+            return SparsePauliOp.sum(hamiltonians)
+        else:
+            # Parametric weighted sum
+            params = [Parameter(name) for name in param_names]
+            weighted_terms = [c * H for c, H in zip(params, hamiltonians)]
+            return SparsePauliOp.sum(weighted_terms)
+
+    def test_parametric_identical_structures(self):
+        """Test parameter preservation with identical graph structures.
+
+        When multiple objectives have identical structures but different
+        parametric coefficients, all parameters must be preserved.
+        """
+        # Create 3 complete graphs with identical structure
+        graphs = [nx.complete_graph(4) for _ in range(3)]
+        for i, G in enumerate(graphs):
+            for u, v in G.edges():
+                G[u][v]["weight"] = float(i + 1)
+
+        # Build parametric Hamiltonian
+        hamiltonian = self._build_hamiltonian_from_graphs(graphs, ["c_0", "c_1", "c_2"])
+        circuit = annotated_qaoa_ansatz(hamiltonian, reps=1)
+
+        # Test AnnotatedPrepareCostLayer
+        pm = PassManager([AnnotatedPrepareCostLayer()])
+        result = pm.run(circuit)
+        params = {p.name for p in result.parameters}
+
+        # All parametric coefficients must be preserved
+        self.assertEqual(params, {"c_0", "c_1", "c_2", "β[0]", "γ[0]"})
+
+    def test_parametric_single_objective(self):
+        """Test single parametric objective is preserved."""
+        G = nx.complete_graph(4)
+        for u, v in G.edges():
+            G[u][v]["weight"] = 1.0
+
+        hamiltonian = self._build_hamiltonian_from_graphs([G], ["c_0"])
+        circuit = annotated_qaoa_ansatz(hamiltonian, reps=1)
+
+        pm = PassManager([AnnotatedPrepareCostLayer()])
+        result = pm.run(circuit)
+        params = {p.name for p in result.parameters}
+
+        self.assertEqual(params, {"c_0", "β[0]", "γ[0]"})
+
+    def test_numeric_circuit_optimization(self):
+        """Test numeric circuits are optimized correctly.
+
+        For fully numeric cost Hamiltonians, the AnnotatedPrepareCostLayer
+        pass absorbs γ (cost layer) parameters into the Commuting2qBlock
+        structure for optimization. β (mixer layer) parameters remain
+        visible as they are not processed by this pass.
+        """
+        # Create 2 graphs with numeric weights
+        graphs = [nx.complete_graph(4) for _ in range(2)]
+        for i, G in enumerate(graphs):
+            for u, v in G.edges():
+                G[u][v]["weight"] = float(i + 1)
+
+        hamiltonian = self._build_hamiltonian_from_graphs(graphs)
+        circuit = annotated_qaoa_ansatz(hamiltonian, reps=1)
+
+        pm = PassManager([AnnotatedPrepareCostLayer()])
+        result = pm.run(circuit)
+        params = {p.name for p in result.parameters}
+
+        # γ absorbed into Commuting2qBlock, β remains (in mixer layer)
+        self.assertEqual(params, {"β[0]"})
 
 
 if __name__ == "__main__":

--- a/test/test_annotated_transpilation.py
+++ b/test/test_annotated_transpilation.py
@@ -109,7 +109,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
     def _estimate(self, circuit, hamiltonian, param_values):
         circuit.remove_final_measurements()
         isa_hamiltonian = hamiltonian.apply_layout(circuit.layout)
-        result = self.estimator.run([(circuit, isa_hamiltonian, param_values)]).result()[0]
+        result = self.estimator.run(
+            [(circuit, isa_hamiltonian, param_values)]
+        ).result()[0]
         return list(result.data.values())
 
     def _assert_equivalence(self, expvals_1, expvals_2, circuit_1, circuit_2):
@@ -159,7 +161,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         ]
         if optimized:
             annot_passes.append(
-                SynthesizeAndSimplifyCostLayer(basis_gates=["x", "cx", "sx", "rz", "id"])
+                SynthesizeAndSimplifyCostLayer(
+                    basis_gates=["x", "cx", "sx", "rz", "id"]
+                )
             )
         annot_passes.append(UnrollBoxes())
 
@@ -186,7 +190,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         swap_strategy, edge_coloring = self._get_swap_strategy(cost_layer)
 
         # Standard pipeline
-        standard_ansatz = qaoa_ansatz(hamiltonian, reps=num_qaoa_layers, mixer_operator=mixer_op)
+        standard_ansatz = qaoa_ansatz(
+            hamiltonian, reps=num_qaoa_layers, mixer_operator=mixer_op
+        )
         standard_pm = generate_preset_pass_manager(
             backend=backend, optimization_level=3, initial_layout=initial_layout
         )
@@ -204,7 +210,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         ]
         if optimized:
             annot_passes.append(
-                SynthesizeAndSimplifyCostLayer(basis_gates=["x", "cx", "sx", "rz", "id"])
+                SynthesizeAndSimplifyCostLayer(
+                    basis_gates=["x", "cx", "sx", "rz", "id"]
+                )
             )
         annot_passes.append(UnrollBoxes())
 
@@ -234,7 +242,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         )
         eval_qopt = self._estimate(qopt_transpiled, hamiltonian, param_values)
         eval_annot = self._estimate(annot_transpiled, hamiltonian, param_values)
-        self._assert_equivalence(eval_annot, eval_qopt, annot_transpiled, qopt_transpiled)
+        self._assert_equivalence(
+            eval_annot, eval_qopt, annot_transpiled, qopt_transpiled
+        )
 
     def _run_comparison_standard(  # pylint: disable=too-many-positional-arguments
         self,
@@ -262,7 +272,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         eval_standard = self._estimate(standard_transpiled, hamiltonian, param_values)
         eval_annot = self._estimate(annot_transpiled, hamiltonian, param_values)
 
-        self._assert_equivalence(eval_annot, eval_standard, annot_transpiled, standard_transpiled)
+        self._assert_equivalence(
+            eval_annot, eval_standard, annot_transpiled, standard_transpiled
+        )
 
     def _run_all_cases(self, problem_fn, optimized=False):
         """Iterate over given test cases and run"""
@@ -280,7 +292,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
             with self.subTest(layers=layers, nodes=nodes, edges=edges):
                 hamiltonian, cost_layer, _ = get_problem_barabasi(n=nodes, m=edges)
                 backend, initial_layout = backend_and_layout_a(cost_layer)
-                self._run_comparison_qopt(hamiltonian, cost_layer, layers, backend, initial_layout)
+                self._run_comparison_qopt(
+                    hamiltonian, cost_layer, layers, backend, initial_layout
+                )
 
     def test_barabasi_albert_optimized(self):
         """Run comparison with barabasi albert graph and an additional synthesis/cancellation step."""
@@ -375,7 +389,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
             if inst.operation.name == "box":
                 if "cost_layer" in inst.operation.annotations[0].namespace:
                     box_circ = inst.operation.params[0]
-                    self.assertEqual(box_circ.count_ops(), {"rz": 4, "commuting_2q_block": 1})
+                    self.assertEqual(
+                        box_circ.count_ops(), {"rz": 4, "commuting_2q_block": 1}
+                    )
 
 
 class TestAnnotatedPrepareCostLayerParametric(unittest.TestCase):
@@ -418,7 +434,8 @@ class TestAnnotatedPrepareCostLayerParametric(unittest.TestCase):
         """Test parameter preservation with identical graph structures.
 
         When multiple objectives have identical structures but different
-        parametric coefficients, all parameters must be preserved.
+        parametric coefficients, all parameters must be preserved in the
+        Commuting2qBlock. The block preserves individual gate parameters.
         """
         # Create 3 complete graphs with identical structure
         graphs = [nx.complete_graph(4) for _ in range(3)]
@@ -435,7 +452,8 @@ class TestAnnotatedPrepareCostLayerParametric(unittest.TestCase):
         result = pm.run(circuit)
         params = {p.name for p in result.parameters}
 
-        # All parametric coefficients must be preserved
+        # All parametric coefficients are preserved in Commuting2qBlock
+        # β remains visible (in mixer layer), γ and c_i are in the cost block
         self.assertEqual(params, {"c_0", "c_1", "c_2", "β[0]", "γ[0]"})
 
     def test_parametric_single_objective(self):
@@ -451,6 +469,7 @@ class TestAnnotatedPrepareCostLayerParametric(unittest.TestCase):
         result = pm.run(circuit)
         params = {p.name for p in result.parameters}
 
+        # c_0 and γ[0] preserved in Commuting2qBlock, β[0] in mixer
         self.assertEqual(params, {"c_0", "β[0]", "γ[0]"})
 
     def test_numeric_circuit_optimization(self):

--- a/test/test_annotated_transpilation.py
+++ b/test/test_annotated_transpilation.py
@@ -109,9 +109,7 @@ class TestAnnotatedTranspilation(unittest.TestCase):
     def _estimate(self, circuit, hamiltonian, param_values):
         circuit.remove_final_measurements()
         isa_hamiltonian = hamiltonian.apply_layout(circuit.layout)
-        result = self.estimator.run(
-            [(circuit, isa_hamiltonian, param_values)]
-        ).result()[0]
+        result = self.estimator.run([(circuit, isa_hamiltonian, param_values)]).result()[0]
         return list(result.data.values())
 
     def _assert_equivalence(self, expvals_1, expvals_2, circuit_1, circuit_2):
@@ -161,9 +159,7 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         ]
         if optimized:
             annot_passes.append(
-                SynthesizeAndSimplifyCostLayer(
-                    basis_gates=["x", "cx", "sx", "rz", "id"]
-                )
+                SynthesizeAndSimplifyCostLayer(basis_gates=["x", "cx", "sx", "rz", "id"])
             )
         annot_passes.append(UnrollBoxes())
 
@@ -190,9 +186,7 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         swap_strategy, edge_coloring = self._get_swap_strategy(cost_layer)
 
         # Standard pipeline
-        standard_ansatz = qaoa_ansatz(
-            hamiltonian, reps=num_qaoa_layers, mixer_operator=mixer_op
-        )
+        standard_ansatz = qaoa_ansatz(hamiltonian, reps=num_qaoa_layers, mixer_operator=mixer_op)
         standard_pm = generate_preset_pass_manager(
             backend=backend, optimization_level=3, initial_layout=initial_layout
         )
@@ -210,9 +204,7 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         ]
         if optimized:
             annot_passes.append(
-                SynthesizeAndSimplifyCostLayer(
-                    basis_gates=["x", "cx", "sx", "rz", "id"]
-                )
+                SynthesizeAndSimplifyCostLayer(basis_gates=["x", "cx", "sx", "rz", "id"])
             )
         annot_passes.append(UnrollBoxes())
 
@@ -242,9 +234,7 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         )
         eval_qopt = self._estimate(qopt_transpiled, hamiltonian, param_values)
         eval_annot = self._estimate(annot_transpiled, hamiltonian, param_values)
-        self._assert_equivalence(
-            eval_annot, eval_qopt, annot_transpiled, qopt_transpiled
-        )
+        self._assert_equivalence(eval_annot, eval_qopt, annot_transpiled, qopt_transpiled)
 
     def _run_comparison_standard(  # pylint: disable=too-many-positional-arguments
         self,
@@ -272,9 +262,7 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         eval_standard = self._estimate(standard_transpiled, hamiltonian, param_values)
         eval_annot = self._estimate(annot_transpiled, hamiltonian, param_values)
 
-        self._assert_equivalence(
-            eval_annot, eval_standard, annot_transpiled, standard_transpiled
-        )
+        self._assert_equivalence(eval_annot, eval_standard, annot_transpiled, standard_transpiled)
 
     def _run_all_cases(self, problem_fn, optimized=False):
         """Iterate over given test cases and run"""
@@ -292,9 +280,7 @@ class TestAnnotatedTranspilation(unittest.TestCase):
             with self.subTest(layers=layers, nodes=nodes, edges=edges):
                 hamiltonian, cost_layer, _ = get_problem_barabasi(n=nodes, m=edges)
                 backend, initial_layout = backend_and_layout_a(cost_layer)
-                self._run_comparison_qopt(
-                    hamiltonian, cost_layer, layers, backend, initial_layout
-                )
+                self._run_comparison_qopt(hamiltonian, cost_layer, layers, backend, initial_layout)
 
     def test_barabasi_albert_optimized(self):
         """Run comparison with barabasi albert graph and an additional synthesis/cancellation step."""
@@ -389,9 +375,7 @@ class TestAnnotatedTranspilation(unittest.TestCase):
             if inst.operation.name == "box":
                 if "cost_layer" in inst.operation.annotations[0].namespace:
                     box_circ = inst.operation.params[0]
-                    self.assertEqual(
-                        box_circ.count_ops(), {"rz": 4, "commuting_2q_block": 1}
-                    )
+                    self.assertEqual(box_circ.count_ops(), {"rz": 4, "commuting_2q_block": 1})
 
 
 class TestAnnotatedPrepareCostLayerParametric(unittest.TestCase):

--- a/test/test_annotated_transpilation.py
+++ b/test/test_annotated_transpilation.py
@@ -109,7 +109,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
     def _estimate(self, circuit, hamiltonian, param_values):
         circuit.remove_final_measurements()
         isa_hamiltonian = hamiltonian.apply_layout(circuit.layout)
-        result = self.estimator.run([(circuit, isa_hamiltonian, param_values)]).result()[0]
+        result = self.estimator.run(
+            [(circuit, isa_hamiltonian, param_values)]
+        ).result()[0]
         return list(result.data.values())
 
     def _assert_equivalence(self, expvals_1, expvals_2, circuit_1, circuit_2):
@@ -159,7 +161,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         ]
         if optimized:
             annot_passes.append(
-                SynthesizeAndSimplifyCostLayer(basis_gates=["x", "cx", "sx", "rz", "id"])
+                SynthesizeAndSimplifyCostLayer(
+                    basis_gates=["x", "cx", "sx", "rz", "id"]
+                )
             )
         annot_passes.append(UnrollBoxes())
 
@@ -186,7 +190,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         swap_strategy, edge_coloring = self._get_swap_strategy(cost_layer)
 
         # Standard pipeline
-        standard_ansatz = qaoa_ansatz(hamiltonian, reps=num_qaoa_layers, mixer_operator=mixer_op)
+        standard_ansatz = qaoa_ansatz(
+            hamiltonian, reps=num_qaoa_layers, mixer_operator=mixer_op
+        )
         standard_pm = generate_preset_pass_manager(
             backend=backend, optimization_level=3, initial_layout=initial_layout
         )
@@ -204,7 +210,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         ]
         if optimized:
             annot_passes.append(
-                SynthesizeAndSimplifyCostLayer(basis_gates=["x", "cx", "sx", "rz", "id"])
+                SynthesizeAndSimplifyCostLayer(
+                    basis_gates=["x", "cx", "sx", "rz", "id"]
+                )
             )
         annot_passes.append(UnrollBoxes())
 
@@ -234,7 +242,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         )
         eval_qopt = self._estimate(qopt_transpiled, hamiltonian, param_values)
         eval_annot = self._estimate(annot_transpiled, hamiltonian, param_values)
-        self._assert_equivalence(eval_annot, eval_qopt, annot_transpiled, qopt_transpiled)
+        self._assert_equivalence(
+            eval_annot, eval_qopt, annot_transpiled, qopt_transpiled
+        )
 
     def _run_comparison_standard(  # pylint: disable=too-many-positional-arguments
         self,
@@ -262,7 +272,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
         eval_standard = self._estimate(standard_transpiled, hamiltonian, param_values)
         eval_annot = self._estimate(annot_transpiled, hamiltonian, param_values)
 
-        self._assert_equivalence(eval_annot, eval_standard, annot_transpiled, standard_transpiled)
+        self._assert_equivalence(
+            eval_annot, eval_standard, annot_transpiled, standard_transpiled
+        )
 
     def _run_all_cases(self, problem_fn, optimized=False):
         """Iterate over given test cases and run"""
@@ -280,7 +292,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
             with self.subTest(layers=layers, nodes=nodes, edges=edges):
                 hamiltonian, cost_layer, _ = get_problem_barabasi(n=nodes, m=edges)
                 backend, initial_layout = backend_and_layout_a(cost_layer)
-                self._run_comparison_qopt(hamiltonian, cost_layer, layers, backend, initial_layout)
+                self._run_comparison_qopt(
+                    hamiltonian, cost_layer, layers, backend, initial_layout
+                )
 
     def test_barabasi_albert_optimized(self):
         """Run comparison with barabasi albert graph and an additional synthesis/cancellation step."""
@@ -375,7 +389,9 @@ class TestAnnotatedTranspilation(unittest.TestCase):
             if inst.operation.name == "box":
                 if "cost_layer" in inst.operation.annotations[0].namespace:
                     box_circ = inst.operation.params[0]
-                    self.assertEqual(box_circ.count_ops(), {"rz": 4, "commuting_2q_block": 1})
+                    self.assertEqual(
+                        box_circ.count_ops(), {"rz": 4, "commuting_2q_block": 1}
+                    )
 
 
 class TestAnnotatedPrepareCostLayerParametric(unittest.TestCase):
@@ -397,11 +413,11 @@ class TestAnnotatedPrepareCostLayerParametric(unittest.TestCase):
         hamiltonians = []
         for graph in graphs:
             pauli_list = []
-            for u, v, data in graph.edges(data=True):
+            for node_u, node_v, data in graph.edges(data=True):
                 weight = data["weight"]
                 pauli_str = ["I"] * len(graph.nodes)
-                pauli_str[len(graph.nodes) - 1 - u] = "Z"
-                pauli_str[len(graph.nodes) - 1 - v] = "Z"
+                pauli_str[len(graph.nodes) - 1 - node_u] = "Z"
+                pauli_str[len(graph.nodes) - 1 - node_v] = "Z"
                 pauli_list.append(("".join(pauli_str), weight))
             hamiltonians.append(SparsePauliOp.from_list(pauli_list))
 
@@ -423,9 +439,9 @@ class TestAnnotatedPrepareCostLayerParametric(unittest.TestCase):
         """
         # Create 3 complete graphs with identical structure
         graphs = [nx.complete_graph(4) for _ in range(3)]
-        for i, G in enumerate(graphs):
-            for u, v in G.edges():
-                G[u][v]["weight"] = float(i + 1)
+        for i, graph in enumerate(graphs):
+            for node_u, node_v in graph.edges():
+                graph[node_u][node_v]["weight"] = float(i + 1)
 
         # Build parametric Hamiltonian
         hamiltonian = self._build_hamiltonian_from_graphs(graphs, ["c_0", "c_1", "c_2"])
@@ -442,11 +458,11 @@ class TestAnnotatedPrepareCostLayerParametric(unittest.TestCase):
 
     def test_parametric_single_objective(self):
         """Test single parametric objective is preserved."""
-        G = nx.complete_graph(4)
-        for u, v in G.edges():
-            G[u][v]["weight"] = 1.0
+        graph = nx.complete_graph(4)
+        for node_u, node_v in graph.edges():
+            graph[node_u][node_v]["weight"] = 1.0
 
-        hamiltonian = self._build_hamiltonian_from_graphs([G], ["c_0"])
+        hamiltonian = self._build_hamiltonian_from_graphs([graph], ["c_0"])
         circuit = annotated_qaoa_ansatz(hamiltonian, reps=1)
 
         pm = PassManager([AnnotatedPrepareCostLayer()])
@@ -466,9 +482,9 @@ class TestAnnotatedPrepareCostLayerParametric(unittest.TestCase):
         """
         # Create 2 graphs with numeric weights
         graphs = [nx.complete_graph(4) for _ in range(2)]
-        for i, G in enumerate(graphs):
-            for u, v in G.edges():
-                G[u][v]["weight"] = float(i + 1)
+        for i, graph in enumerate(graphs):
+            for node_u, node_v in graph.edges():
+                graph[node_u][node_v]["weight"] = float(i + 1)
 
         hamiltonian = self._build_hamiltonian_from_graphs(graphs)
         circuit = annotated_qaoa_ansatz(hamiltonian, reps=1)


### PR DESCRIPTION
**NOTE:** this PR depends on #56  and should be reviewed/merged after it. The additions of this PR to #56 are the changes made in 2 out of the 4 files listed here: 
1. qopt_best_practices/transpilation/annotated_transpilation_passes.py
2. test/test_annotated_transpilation.py
The other two changed files are reviewed in #56 and will be removed from this PR when #56 is merged. 

### Summary

Fixes a critical bug in `AnnotatedPrepareCostLayer` where parametric coefficients (e.g., `c_0, c_1, c_2`) were being lost during transpilation of parametrized QAOA circuits. This enables proper support for parametric Hamiltonians in the annotated transpilation pipeline.

### Details and comments

Problem:
When using parametric Hamiltonians like `H = c_0H_0 + c_1H_1 + c_2*H_2` (common in multi-objective optimization), the `AnnotatedPrepareCostLayer` pass was incorrectly grouping all gates together for optimization, causing custom parameters to be absorbed into the circuit structure and lost. This broke multi-objective workflows where these parameters need to be bound during optimization.

**Solution:**
Added `_group_by_parametric_signature()` function that groups gates based on their parametric structure:

    - Gates with custom parameters (e.g., `c_0γ, c_1γ, c_2*γ`) are kept in separate groups to preserve each parameter independently
    - Gates with only QAOA layer parameters (e.g., `1.0γ, 2.5γ)` are grouped together for optimization

**Key Changes**:

    - New `_group_by_parametric_signature()` helper function in `annotated_transpilation_passes.py`
    - Modified `AnnotatedPrepareCostLayer.run()` to group gates by parametric signature before creating `Commuting2qBlock` structures
    - Added comprehensive tests for parametric Hamiltonian preservation



