### PR TITLE
Allow compatibility with Qiskit 2.4

### DIFF
--- a/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
+++ b/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
@@ -8,6 +8,7 @@ import warnings
 from collections.abc import Sequence
 
 import numpy as np
+from qiskit import __version__ as qiskit_version
 from qiskit.circuit import QuantumCircuit, annotation
 from qiskit.circuit.parametervector import ParameterVector
 from qiskit.quantum_info import Operator, Pauli, SparsePauliOp
@@ -44,6 +45,19 @@ class InitStateAnnotation(annotation.Annotation):
     def __init__(self):
         self.namespace = "qaoa.init_state"
         self.payload = str(1)
+
+
+def _qiskit_version_tuple() -> tuple[int, int]:
+    version_parts = qiskit_version.split(".")
+    major = int(version_parts[0])
+    minor_digits = []
+    for character in version_parts[1]:
+        if character.isdigit():
+            minor_digits.append(character)
+        else:
+            break
+    minor = int("".join(minor_digits)) if minor_digits else 0
+    return major, minor
 
 
 def annotated_evolved_operator_ansatz(  # pylint: disable=too-many-positional-arguments
@@ -309,15 +323,18 @@ def annotated_qaoa_ansatz(  # pylint: disable=too-many-positional-arguments
         copy=False,
     )
 
-    # Prior to Qiskit 2.4, disconnected graphs would create boxes acting on subsets of qubits,
-    # which would be caught by this check. This is no longer the case.
-    # The check below allows boxes with 0 qubits (for dummy mixers) or full circuit qubits.
-    for inst in out_circuit:
-        if inst.operation.name == "box":
-            if inst.operation.num_qubits not in (0, out_circuit.num_qubits):
-                raise NotImplementedError(
-                    f"This constructor does not support disconnected graphs. "
-                    f"Expected instruction to act on {out_circuit.num_qubits}, "
-                    f"instead, got {inst.operation.num_qubits}."
-                )
+    # Prior to Qiskit 2.4, disconnected graphs could create boxes acting on subsets of qubits.
+    # Keep the legacy validation only for those versions. Boxes with 0 qubits are allowed for
+    # dummy mixers.
+
+    if _qiskit_version_tuple() < (2, 4):
+        for inst in out_circuit:
+            if inst.operation.name == "box":
+                if inst.operation.num_qubits not in (0, out_circuit.num_qubits):
+                    raise NotImplementedError(
+                        f"This constructor does not support disconnected graphs on "
+                        f"Qiskit < 2.4. Expected instruction to act on "
+                        f"{out_circuit.num_qubits}, instead, got "
+                        f"{inst.operation.num_qubits}. Please update Qiskit."
+                    )
     return out_circuit

--- a/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
+++ b/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
@@ -144,9 +144,7 @@ def annotated_evolved_operator_ansatz(  # pylint: disable=too-many-positional-ar
         #    [[a0, a1, a2, ...], [b0, b1, b2, ...], [c0, c1, c2, ...]]
         # and turns them into an iterator
         #    a0 -> b0 -> c0 -> a1 -> b1 -> c1 -> a2 -> ...
-        per_operator = [
-            ParameterVector(prefix, reps).params for prefix in parameter_prefix
-        ]
+        per_operator = [ParameterVector(prefix, reps).params for prefix in parameter_prefix]
         param_iter = itertools.chain.from_iterable(zip(*per_operator))
 
     # slower, Python-path
@@ -212,17 +210,13 @@ def _is_pauli_identity(operator):
 
 
 def _remove_identities(operators, prefixes):
-    identity_ops = {
-        index for index, op in enumerate(operators) if _is_pauli_identity(op)
-    }
+    identity_ops = {index for index, op in enumerate(operators) if _is_pauli_identity(op)}
 
     if len(identity_ops) == 0:
         return operators, prefixes
 
     cleaned_ops = [op for i, op in enumerate(operators) if i not in identity_ops]
-    cleaned_prefix = [
-        prefix for i, prefix in enumerate(prefixes) if i not in identity_ops
-    ]
+    cleaned_prefix = [prefix for i, prefix in enumerate(prefixes) if i not in identity_ops]
 
     return cleaned_ops, cleaned_prefix
 

--- a/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
+++ b/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
@@ -144,7 +144,9 @@ def annotated_evolved_operator_ansatz(  # pylint: disable=too-many-positional-ar
         #    [[a0, a1, a2, ...], [b0, b1, b2, ...], [c0, c1, c2, ...]]
         # and turns them into an iterator
         #    a0 -> b0 -> c0 -> a1 -> b1 -> c1 -> a2 -> ...
-        per_operator = [ParameterVector(prefix, reps).params for prefix in parameter_prefix]
+        per_operator = [
+            ParameterVector(prefix, reps).params for prefix in parameter_prefix
+        ]
         param_iter = itertools.chain.from_iterable(zip(*per_operator))
 
     # slower, Python-path
@@ -210,13 +212,17 @@ def _is_pauli_identity(operator):
 
 
 def _remove_identities(operators, prefixes):
-    identity_ops = {index for index, op in enumerate(operators) if _is_pauli_identity(op)}
+    identity_ops = {
+        index for index, op in enumerate(operators) if _is_pauli_identity(op)
+    }
 
     if len(identity_ops) == 0:
         return operators, prefixes
 
     cleaned_ops = [op for i, op in enumerate(operators) if i not in identity_ops]
-    cleaned_prefix = [prefix for i, prefix in enumerate(prefixes) if i not in identity_ops]
+    cleaned_prefix = [
+        prefix for i, prefix in enumerate(prefixes) if i not in identity_ops
+    ]
 
     return cleaned_ops, cleaned_prefix
 
@@ -303,10 +309,6 @@ def annotated_qaoa_ansatz(  # pylint: disable=too-many-positional-arguments
         copy=False,
     )
 
-    # Note: In Qiskit >= 2.4, disconnected graphs are handled correctly.
-    # The check below allows boxes with 0 qubits (for dummy mixers) or full circuit qubits.
-    # Prior to Qiskit 2.4, disconnected graphs would create boxes acting on subsets of qubits,
-    # which would be caught by this check. This is no longer the case.
     for inst in out_circuit:
         if inst.operation.name == "box":
             if inst.operation.num_qubits not in (0, out_circuit.num_qubits):

--- a/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
+++ b/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
@@ -309,6 +309,9 @@ def annotated_qaoa_ansatz(  # pylint: disable=too-many-positional-arguments
         copy=False,
     )
 
+    # Prior to Qiskit 2.4, disconnected graphs would create boxes acting on subsets of qubits,
+    # which would be caught by this check. This is no longer the case.
+    # The check below allows boxes with 0 qubits (for dummy mixers) or full circuit qubits.
     for inst in out_circuit:
         if inst.operation.name == "box":
             if inst.operation.num_qubits not in (0, out_circuit.num_qubits):

--- a/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
+++ b/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+import itertools
 import typing
 import warnings
 from collections.abc import Sequence
-import itertools
-import numpy as np
 
+import numpy as np
 from qiskit.circuit import QuantumCircuit, annotation
 from qiskit.circuit.parametervector import ParameterVector
 from qiskit.quantum_info import Operator, Pauli, SparsePauliOp
@@ -144,7 +144,9 @@ def annotated_evolved_operator_ansatz(  # pylint: disable=too-many-positional-ar
         #    [[a0, a1, a2, ...], [b0, b1, b2, ...], [c0, c1, c2, ...]]
         # and turns them into an iterator
         #    a0 -> b0 -> c0 -> a1 -> b1 -> c1 -> a2 -> ...
-        per_operator = [ParameterVector(prefix, reps).params for prefix in parameter_prefix]
+        per_operator = [
+            ParameterVector(prefix, reps).params for prefix in parameter_prefix
+        ]
         param_iter = itertools.chain.from_iterable(zip(*per_operator))
 
     # slower, Python-path
@@ -210,13 +212,17 @@ def _is_pauli_identity(operator):
 
 
 def _remove_identities(operators, prefixes):
-    identity_ops = {index for index, op in enumerate(operators) if _is_pauli_identity(op)}
+    identity_ops = {
+        index for index, op in enumerate(operators) if _is_pauli_identity(op)
+    }
 
     if len(identity_ops) == 0:
         return operators, prefixes
 
     cleaned_ops = [op for i, op in enumerate(operators) if i not in identity_ops]
-    cleaned_prefix = [prefix for i, prefix in enumerate(prefixes) if i not in identity_ops]
+    cleaned_prefix = [
+        prefix for i, prefix in enumerate(prefixes) if i not in identity_ops
+    ]
 
     return cleaned_ops, cleaned_prefix
 
@@ -303,12 +309,16 @@ def annotated_qaoa_ansatz(  # pylint: disable=too-many-positional-arguments
         copy=False,
     )
 
+    # Note: In Qiskit >= 2.4, disconnected graphs are handled correctly.
+    # The check below allows boxes with 0 qubits (for dummy mixers) or full circuit qubits.
+    # Prior to Qiskit 2.4, disconnected graphs would create boxes acting on subsets of qubits,
+    # which would be caught by this check. This is no longer the case.
     for inst in out_circuit:
         if inst.operation.name == "box":
             if inst.operation.num_qubits not in (0, out_circuit.num_qubits):
                 raise NotImplementedError(
-                    "This constructor does not support incomplete graphs. ",
-                    f"Expected instruction to act on {out_circuit.num_qubits}, ",
-                    f"instead, got {inst.operation.num_qubits}.",
+                    f"This constructor does not support disconnected graphs. "
+                    f"Expected instruction to act on {out_circuit.num_qubits}, "
+                    f"instead, got {inst.operation.num_qubits}."
                 )
     return out_circuit

--- a/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
+++ b/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
@@ -69,7 +69,7 @@ def annotated_evolved_operator_ansatz(  # pylint: disable=too-many-positional-ar
     parameter_prefix: str | Sequence[str] = "t",
     remove_identities: bool = True,
     flatten: bool | None = None,
-    annotations: Sequence[annotation.Annotation] = None,
+    annotations: Sequence[annotation.Annotation] | None = None,
 ) -> QuantumCircuit:
     r"""Construct an ansatz out of operator evolutions with a series of annotations
 
@@ -158,9 +158,7 @@ def annotated_evolved_operator_ansatz(  # pylint: disable=too-many-positional-ar
         #    [[a0, a1, a2, ...], [b0, b1, b2, ...], [c0, c1, c2, ...]]
         # and turns them into an iterator
         #    a0 -> b0 -> c0 -> a1 -> b1 -> c1 -> a2 -> ...
-        per_operator = [
-            ParameterVector(prefix, reps).params for prefix in parameter_prefix
-        ]
+        per_operator = [ParameterVector(prefix, reps).params for prefix in parameter_prefix]
         param_iter = itertools.chain.from_iterable(zip(*per_operator))
 
     # slower, Python-path
@@ -226,17 +224,13 @@ def _is_pauli_identity(operator):
 
 
 def _remove_identities(operators, prefixes):
-    identity_ops = {
-        index for index, op in enumerate(operators) if _is_pauli_identity(op)
-    }
+    identity_ops = {index for index, op in enumerate(operators) if _is_pauli_identity(op)}
 
     if len(identity_ops) == 0:
         return operators, prefixes
 
     cleaned_ops = [op for i, op in enumerate(operators) if i not in identity_ops]
-    cleaned_prefix = [
-        prefix for i, prefix in enumerate(prefixes) if i not in identity_ops
-    ]
+    cleaned_prefix = [prefix for i, prefix in enumerate(prefixes) if i not in identity_ops]
 
     return cleaned_ops, cleaned_prefix
 

--- a/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
+++ b/qopt_best_practices/circuit_library/annotated_qaoa_ansatz.py
@@ -144,7 +144,9 @@ def annotated_evolved_operator_ansatz(  # pylint: disable=too-many-positional-ar
         #    [[a0, a1, a2, ...], [b0, b1, b2, ...], [c0, c1, c2, ...]]
         # and turns them into an iterator
         #    a0 -> b0 -> c0 -> a1 -> b1 -> c1 -> a2 -> ...
-        per_operator = [ParameterVector(prefix, reps).params for prefix in parameter_prefix]
+        per_operator = [
+            ParameterVector(prefix, reps).params for prefix in parameter_prefix
+        ]
         param_iter = itertools.chain.from_iterable(zip(*per_operator))
 
     # slower, Python-path
@@ -210,13 +212,17 @@ def _is_pauli_identity(operator):
 
 
 def _remove_identities(operators, prefixes):
-    identity_ops = {index for index, op in enumerate(operators) if _is_pauli_identity(op)}
+    identity_ops = {
+        index for index, op in enumerate(operators) if _is_pauli_identity(op)
+    }
 
     if len(identity_ops) == 0:
         return operators, prefixes
 
     cleaned_ops = [op for i, op in enumerate(operators) if i not in identity_ops]
-    cleaned_prefix = [prefix for i, prefix in enumerate(prefixes) if i not in identity_ops]
+    cleaned_prefix = [
+        prefix for i, prefix in enumerate(prefixes) if i not in identity_ops
+    ]
 
     return cleaned_ops, cleaned_prefix
 

--- a/test/test_annotated_qaoa_ansatz.py
+++ b/test/test_annotated_qaoa_ansatz.py
@@ -1,14 +1,14 @@
 """Unit tests for the annotated qaoa ansatz function."""
 
 import unittest
-from networkx import barabasi_albert_graph
 
+from networkx import barabasi_albert_graph
 from qiskit import QuantumCircuit
-from qiskit.circuit import ParameterVector, ParameterExpression
+from qiskit.circuit import ParameterExpression, ParameterVector
 from qiskit.quantum_info import SparsePauliOp
 
-from qopt_best_practices.utils import build_max_cut_paulis
 from qopt_best_practices.circuit_library import annotated_qaoa_ansatz
+from qopt_best_practices.utils import build_max_cut_paulis
 
 
 class TestAnnotatedQAOAAnsatz(unittest.TestCase):
@@ -37,9 +37,13 @@ class TestAnnotatedQAOAAnsatz(unittest.TestCase):
         for i, instr in enumerate(circuit.data):
             self.assertEqual(instr.operation.name, "box")
             if i == 0:
-                self.assertEqual(instr.operation.annotations[0].namespace, "qaoa.init_state")
+                self.assertEqual(
+                    instr.operation.annotations[0].namespace, "qaoa.init_state"
+                )
             elif i == 1:
-                self.assertEqual(instr.operation.annotations[0].namespace, "qaoa.cost_layer")
+                self.assertEqual(
+                    instr.operation.annotations[0].namespace, "qaoa.cost_layer"
+                )
             else:
                 self.assertEqual(instr.operation.annotations[0].namespace, "qaoa.mixer")
 
@@ -79,28 +83,52 @@ class TestAnnotatedQAOAAnsatz(unittest.TestCase):
                 self.assertEqual(instr.operation.annotations[0].payload, "3")
 
     def test_disconnected_graph(self):
-        """Check that the constructor will fail if the graph is disconnected."""
+        """Check that disconnected graphs are handled correctly in Qiskit >= 2.4.
+
+        Note: Prior to Qiskit 2.4, disconnected graphs would create boxes acting on
+        subsets of qubits, which would raise NotImplementedError. In Qiskit 2.4+,
+        all boxes act on all qubits, so disconnected graphs work correctly.
+        """
 
         cost_op = SparsePauliOp.from_list(
             [
                 ("IIIIIIIIIIIZIIIIIIIIZIIIIIIIIIIIIIIIIII", (-0.7052117420058351 + 0j)),
-                ("IIIIIIIIIIIZIIIIZIIIIIIIIIIIIIIIIIIIIII", (-0.41310912458730803 + 0j)),
-                ("IIIIIIIIIIIIIIIIZZIIIIIIIIIIIIIIIIIIIII", (-0.13889026348769137 + 0j)),
+                (
+                    "IIIIIIIIIIIZIIIIZIIIIIIIIIIIIIIIIIIIIII",
+                    (-0.41310912458730803 + 0j),
+                ),
+                (
+                    "IIIIIIIIIIIIIIIIZZIIIIIIIIIIIIIIIIIIIII",
+                    (-0.13889026348769137 + 0j),
+                ),
                 ("IIIIIIIIIIIIIIIIIIIIIIIIIIIIZZIIIIIIIII", (-1.2611637053747173 + 0j)),
                 ("IIIIIIIIIIIIIIIIIIIIIIIIIIIIIZIIZIIIIII", (-0.7849745661237995 + 0j)),
                 ("IIIIIIIIIIIIIIIIIIIIIIIIIIIIIZIIIIIIIIZ", (0.7613352014865872 + 0j)),
                 ("IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIZZ", (-1.171616190854362 + 0j)),
                 ("IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIZZI", (0.04701291466680199 + 0j)),
-                ("IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIZIIIIIZI", (-0.40542381697372243 + 0j)),
+                (
+                    "IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIZIIIIIZI",
+                    (-0.40542381697372243 + 0j),
+                ),
                 ("IIIIIIIIIIIIIIIIIIIIIIIIIIZZIIIIIIIIIII", (-0.6962346022159056 + 0j)),
                 ("IIIIIIIIIIIIIIIIIIIIIIIIIIIZIIIIIIIIZII", (0.1925567945293817 + 0j)),
                 ("IIIIIIIIIIIIIIIIIIIIIIZZIIIIIIIIIIIIIII", (-0.2766391151103169 + 0j)),
-                ("IIIIIIIIIIIIIZIIIIIIIIZIIIIIIIIIIIIIIII", (-0.010835558499671294 + 0j)),
+                (
+                    "IIIIIIIIIIIIIZIIIIIIIIZIIIIIIIIIIIIIIII",
+                    (-0.010835558499671294 + 0j),
+                ),
             ]
         )
 
-        with self.assertRaises(NotImplementedError):
-            _ = annotated_qaoa_ansatz(cost_op, reps=2)
+        circuit = annotated_qaoa_ansatz(cost_op, reps=2)
+
+        # Verify the circuit was created successfully
+        self.assertEqual(circuit.num_qubits, 39)
+        self.assertEqual(len(circuit.parameters), 4)  # 2 reps * 2 params (gamma, beta)
+
+        # Verify parameters can be bound
+        bound_circuit = circuit.assign_parameters({p: 0.1 for p in circuit.parameters})
+        self.assertEqual(bound_circuit.num_qubits, 39)
 
     def test_dummy_mixer(self):
         """Check that dummy mixers pass constructor checks."""

--- a/test/test_annotated_qaoa_ansatz.py
+++ b/test/test_annotated_qaoa_ansatz.py
@@ -37,13 +37,9 @@ class TestAnnotatedQAOAAnsatz(unittest.TestCase):
         for i, instr in enumerate(circuit.data):
             self.assertEqual(instr.operation.name, "box")
             if i == 0:
-                self.assertEqual(
-                    instr.operation.annotations[0].namespace, "qaoa.init_state"
-                )
+                self.assertEqual(instr.operation.annotations[0].namespace, "qaoa.init_state")
             elif i == 1:
-                self.assertEqual(
-                    instr.operation.annotations[0].namespace, "qaoa.cost_layer"
-                )
+                self.assertEqual(instr.operation.annotations[0].namespace, "qaoa.cost_layer")
             else:
                 self.assertEqual(instr.operation.annotations[0].namespace, "qaoa.mixer")
 

--- a/test/test_annotated_qaoa_ansatz.py
+++ b/test/test_annotated_qaoa_ansatz.py
@@ -4,11 +4,18 @@ import unittest
 
 from networkx import barabasi_albert_graph
 from qiskit import QuantumCircuit
+from qiskit import __version__ as qiskit_version
 from qiskit.circuit import ParameterExpression, ParameterVector
 from qiskit.quantum_info import SparsePauliOp
 
 from qopt_best_practices.circuit_library import annotated_qaoa_ansatz
 from qopt_best_practices.utils import build_max_cut_paulis
+
+
+def _qiskit_version_tuple():
+    """Parse Qiskit version string into tuple of integers."""
+    version_parts = qiskit_version.split(".")
+    return tuple(int(part) for part in version_parts[:2])
 
 
 class TestAnnotatedQAOAAnsatz(unittest.TestCase):
@@ -37,9 +44,13 @@ class TestAnnotatedQAOAAnsatz(unittest.TestCase):
         for i, instr in enumerate(circuit.data):
             self.assertEqual(instr.operation.name, "box")
             if i == 0:
-                self.assertEqual(instr.operation.annotations[0].namespace, "qaoa.init_state")
+                self.assertEqual(
+                    instr.operation.annotations[0].namespace, "qaoa.init_state"
+                )
             elif i == 1:
-                self.assertEqual(instr.operation.annotations[0].namespace, "qaoa.cost_layer")
+                self.assertEqual(
+                    instr.operation.annotations[0].namespace, "qaoa.cost_layer"
+                )
             else:
                 self.assertEqual(instr.operation.annotations[0].namespace, "qaoa.mixer")
 
@@ -116,15 +127,28 @@ class TestAnnotatedQAOAAnsatz(unittest.TestCase):
             ]
         )
 
-        circuit = annotated_qaoa_ansatz(cost_op, reps=2)
+        qiskit_ver = _qiskit_version_tuple()
 
-        # Verify the circuit was created successfully
-        self.assertEqual(circuit.num_qubits, 39)
-        self.assertEqual(len(circuit.parameters), 4)  # 2 reps * 2 params (gamma, beta)
+        if qiskit_ver < (2, 4):
+            # In Qiskit < 2.4, disconnected graphs are not supported
+            with self.assertRaises(NotImplementedError) as context:
+                annotated_qaoa_ansatz(cost_op, reps=2)
+            self.assertIn("disconnected graphs", str(context.exception))
+        else:
+            # In Qiskit >= 2.4, disconnected graphs should work
+            circuit = annotated_qaoa_ansatz(cost_op, reps=2)
 
-        # Verify parameters can be bound
-        bound_circuit = circuit.assign_parameters({p: 0.1 for p in circuit.parameters})
-        self.assertEqual(bound_circuit.num_qubits, 39)
+            # Verify the circuit was created successfully
+            self.assertEqual(circuit.num_qubits, 39)
+            self.assertEqual(
+                len(circuit.parameters), 4
+            )  # 2 reps * 2 params (gamma, beta)
+
+            # Verify parameters can be bound
+            bound_circuit = circuit.assign_parameters(
+                {p: 0.1 for p in circuit.parameters}
+            )
+            self.assertEqual(bound_circuit.num_qubits, 39)
 
     def test_dummy_mixer(self):
         """Check that dummy mixers pass constructor checks."""

--- a/test/test_annotated_qaoa_ansatz.py
+++ b/test/test_annotated_qaoa_ansatz.py
@@ -44,13 +44,9 @@ class TestAnnotatedQAOAAnsatz(unittest.TestCase):
         for i, instr in enumerate(circuit.data):
             self.assertEqual(instr.operation.name, "box")
             if i == 0:
-                self.assertEqual(
-                    instr.operation.annotations[0].namespace, "qaoa.init_state"
-                )
+                self.assertEqual(instr.operation.annotations[0].namespace, "qaoa.init_state")
             elif i == 1:
-                self.assertEqual(
-                    instr.operation.annotations[0].namespace, "qaoa.cost_layer"
-                )
+                self.assertEqual(instr.operation.annotations[0].namespace, "qaoa.cost_layer")
             else:
                 self.assertEqual(instr.operation.annotations[0].namespace, "qaoa.mixer")
 
@@ -140,14 +136,10 @@ class TestAnnotatedQAOAAnsatz(unittest.TestCase):
 
             # Verify the circuit was created successfully
             self.assertEqual(circuit.num_qubits, 39)
-            self.assertEqual(
-                len(circuit.parameters), 4
-            )  # 2 reps * 2 params (gamma, beta)
+            self.assertEqual(len(circuit.parameters), 4)  # 2 reps * 2 params (gamma, beta)
 
             # Verify parameters can be bound
-            bound_circuit = circuit.assign_parameters(
-                {p: 0.1 for p in circuit.parameters}
-            )
+            bound_circuit = circuit.assign_parameters({p: 0.1 for p in circuit.parameters})
             self.assertEqual(bound_circuit.num_qubits, 39)
 
     def test_dummy_mixer(self):


### PR DESCRIPTION
### Summary
This PR fixes a failing test caused by behavioral changes in `Qiskit 2.4` regarding how circuits with disconnected graphs are constructed. The test `test_disconnected_graph` was expecting a `NotImplementedError` to be raised, but `Qiskit 2.4` now handles disconnected graphs correctly.


### Details and comments
`Qiskit 2.4` changed circuit composition behavior - all boxes now span the full qubit register, even for disconnected graphs. 

This means the original check for disconnected graphs no longer detects them. Disconnected graphs now work correctly and produce valid circuits.

Changes: Updated `test_disconnected_graph` to verify correct behavior (circuit creation, parameter binding)
Added documentation explaining the Qiskit version dependency
Fixed `NotImplementedError` message formatting
