### PR TITLE
Get sat mapping to support parametric hamiltonian

### DIFF
--- a/qopt_best_practices/sat_mapping/sat_mapper.py
+++ b/qopt_best_practices/sat_mapping/sat_mapper.py
@@ -13,6 +13,7 @@ import networkx as nx
 import numpy as np
 from pysat.formula import CNF, IDPool
 from pysat.solvers import Solver
+from qiskit.circuit import ParameterExpression
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import SwapStrategy
 
@@ -229,14 +230,30 @@ class SATMapper:
     @staticmethod
     def op2graph(operator: SparsePauliOp) -> nx.Graph:
         """Convert a cost operator to a graph."""
+
+        def if_num_to_real(
+            value: complex | float | ParameterExpression,
+        ) -> float | ParameterExpression:
+            """Extract real part from numeric values, preserve ParameterExpression.
+            Raises:
+                TypeError: If value is not numeric or ParameterExpression.
+            """
+            if isinstance(value, ParameterExpression):
+                return value
+            if isinstance(value, (int, float, complex, np.number)):
+                return float(np.real(value))
+            raise TypeError(
+                f"Expected numeric value or ParameterExpression, got {type(value).__name__}"
+            )
+
         graph, edges = nx.Graph(), []
         for pauli_str, weight in operator.to_list():
             edge = [idx for idx, char in enumerate(pauli_str[::-1]) if char == "Z"]
 
             if len(edge) == 1:
-                edges.append((edge[0], edge[0], weight))
+                edges.append((edge[0], edge[0], if_num_to_real(weight)))
             elif len(edge) == 2:
-                edges.append((edge[0], edge[1], weight))
+                edges.append((edge[0], edge[1], if_num_to_real(weight)))
             else:
                 raise ValueError(f"The operator {operator} is not Quadratic.")
 

--- a/qopt_best_practices/sat_mapping/sat_mapper.py
+++ b/qopt_best_practices/sat_mapping/sat_mapper.py
@@ -3,18 +3,16 @@ using the SAT approach from https://arxiv.org/abs/2212.05666.
 """
 
 from __future__ import annotations
-from typing import Union
 
 from dataclasses import dataclass
 from itertools import combinations
 from threading import Timer
+from typing import Union
 
 import networkx as nx
 import numpy as np
-
 from pysat.formula import CNF, IDPool
 from pysat.solvers import Solver
-
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import SwapStrategy
 
@@ -23,9 +21,13 @@ from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import SwapStrat
 class SATResult:
     """A data class to hold the result of a SAT solver."""
 
-    satisfiable: bool  # Satisfiable is True if the SAT model could be solved in a given time.
+    satisfiable: (
+        bool  # Satisfiable is True if the SAT model could be solved in a given time.
+    )
     solution: dict  # The solution to the SAT problem if it is satisfiable.
-    mapping: list  # The mapping of nodes in the pattern graph to nodes in the target graph.
+    mapping: (
+        list  # The mapping of nodes in the pattern graph to nodes in the target graph.
+    )
     elapsed_time: float  # The time it took to solve the SAT model.
 
 
@@ -126,7 +128,9 @@ class SATMapper:
             # full connectivity then its distance matrix will have entries with -1. These
             # entries must be treated as False.
             d_matrix = swap_strategy.distance_matrix
-            connectivity_matrix = ((-1 < d_matrix) & (d_matrix <= num_layers)).astype(int)
+            connectivity_matrix = ((-1 < d_matrix) & (d_matrix <= num_layers)).astype(
+                int
+            )
             # Make a cnf for the adjacency constraint
             cnf2 = []
             for e_0, e_1 in program_graph.edges:
@@ -157,11 +161,15 @@ class SATMapper:
                 if status:
                     # If the SAT problem is satisfiable, convert the solution to a mapping.
                     mapping = [vid2mapping[idx] for idx in sol if idx > 0]
-                    binary_search_results[num_layers] = SATResult(status, sol, mapping, e_time)
+                    binary_search_results[num_layers] = SATResult(
+                        status, sol, mapping, e_time
+                    )
                     max_layers = num_layers
                 else:
                     # If the SAT problem is unsatisfiable, return the last satisfiable solution.
-                    binary_search_results[num_layers] = SATResult(status, sol, [], e_time)
+                    binary_search_results[num_layers] = SATResult(
+                        status, sol, [], e_time
+                    )
                     min_layers = num_layers + 1
 
         return binary_search_results

--- a/qopt_best_practices/sat_mapping/sat_mapper.py
+++ b/qopt_best_practices/sat_mapping/sat_mapper.py
@@ -22,13 +22,9 @@ from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import SwapStrat
 class SATResult:
     """A data class to hold the result of a SAT solver."""
 
-    satisfiable: (
-        bool  # Satisfiable is True if the SAT model could be solved in a given time.
-    )
+    satisfiable: (bool)  # Satisfiable is True if the SAT model could be solved in a given time.
     solution: dict  # The solution to the SAT problem if it is satisfiable.
-    mapping: (
-        list  # The mapping of nodes in the pattern graph to nodes in the target graph.
-    )
+    mapping: (list)  # The mapping of nodes in the pattern graph to nodes in the target graph.
     elapsed_time: float  # The time it took to solve the SAT model.
 
 
@@ -129,9 +125,7 @@ class SATMapper:
             # full connectivity then its distance matrix will have entries with -1. These
             # entries must be treated as False.
             d_matrix = swap_strategy.distance_matrix
-            connectivity_matrix = ((-1 < d_matrix) & (d_matrix <= num_layers)).astype(
-                int
-            )
+            connectivity_matrix = ((-1 < d_matrix) & (d_matrix <= num_layers)).astype(int)
             # Make a cnf for the adjacency constraint
             cnf2 = []
             for e_0, e_1 in program_graph.edges:
@@ -162,15 +156,11 @@ class SATMapper:
                 if status:
                     # If the SAT problem is satisfiable, convert the solution to a mapping.
                     mapping = [vid2mapping[idx] for idx in sol if idx > 0]
-                    binary_search_results[num_layers] = SATResult(
-                        status, sol, mapping, e_time
-                    )
+                    binary_search_results[num_layers] = SATResult(status, sol, mapping, e_time)
                     max_layers = num_layers
                 else:
                     # If the SAT problem is unsatisfiable, return the last satisfiable solution.
-                    binary_search_results[num_layers] = SATResult(
-                        status, sol, [], e_time
-                    )
+                    binary_search_results[num_layers] = SATResult(status, sol, [], e_time)
                     min_layers = num_layers + 1
 
         return binary_search_results

--- a/qopt_best_practices/sat_mapping/sat_mapper.py
+++ b/qopt_best_practices/sat_mapping/sat_mapper.py
@@ -234,9 +234,9 @@ class SATMapper:
             edge = [idx for idx, char in enumerate(pauli_str[::-1]) if char == "Z"]
 
             if len(edge) == 1:
-                edges.append((edge[0], edge[0], np.real(weight)))
+                edges.append((edge[0], edge[0], weight))
             elif len(edge) == 2:
-                edges.append((edge[0], edge[1], np.real(weight)))
+                edges.append((edge[0], edge[1], weight))
             else:
                 raise ValueError(f"The operator {operator} is not Quadratic.")
 

--- a/qopt_best_practices/sat_mapping/sat_mapper.py
+++ b/qopt_best_practices/sat_mapping/sat_mapper.py
@@ -18,13 +18,27 @@ from qiskit.quantum_info import SparsePauliOp
 from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import SwapStrategy
 
 
+def if_num_to_real(
+    value: complex | float | ParameterExpression,
+) -> float | ParameterExpression:
+    """Extract real part from numeric values, preserve ParameterExpression.
+    Raises:
+        TypeError: If value is not numeric or ParameterExpression.
+    """
+    if isinstance(value, ParameterExpression):
+        return value
+    if isinstance(value, (int, float, complex, np.number)):
+        return float(np.real(value))
+    raise TypeError(f"Expected numeric value or ParameterExpression, got {type(value).__name__}")
+
+
 @dataclass
 class SATResult:
     """A data class to hold the result of a SAT solver."""
 
-    satisfiable: (bool)  # Satisfiable is True if the SAT model could be solved in a given time.
+    satisfiable: bool  # Satisfiable is True if the SAT model could be solved in a given time.
     solution: dict  # The solution to the SAT problem if it is satisfiable.
-    mapping: (list)  # The mapping of nodes in the pattern graph to nodes in the target graph.
+    mapping: list  # The mapping of nodes in the pattern graph to nodes in the target graph.
     elapsed_time: float  # The time it took to solve the SAT model.
 
 
@@ -220,21 +234,6 @@ class SATMapper:
     @staticmethod
     def op2graph(operator: SparsePauliOp) -> nx.Graph:
         """Convert a cost operator to a graph."""
-
-        def if_num_to_real(
-            value: complex | float | ParameterExpression,
-        ) -> float | ParameterExpression:
-            """Extract real part from numeric values, preserve ParameterExpression.
-            Raises:
-                TypeError: If value is not numeric or ParameterExpression.
-            """
-            if isinstance(value, ParameterExpression):
-                return value
-            if isinstance(value, (int, float, complex, np.number)):
-                return float(np.real(value))
-            raise TypeError(
-                f"Expected numeric value or ParameterExpression, got {type(value).__name__}"
-            )
 
         graph, edges = nx.Graph(), []
         for pauli_str, weight in operator.to_list():

--- a/test/test_sat_mapping.py
+++ b/test/test_sat_mapping.py
@@ -19,9 +19,7 @@ class TestSwapStrategies(TestCase):
         super().setUp()
 
         # load data
-        graph_file = os.path.join(
-            os.path.dirname(__file__), "data/graph_2layers_0seed.json"
-        )
+        graph_file = os.path.join(os.path.dirname(__file__), "data/graph_2layers_0seed.json")
 
         with open(graph_file, "r") as file:
             data = json.load(file)
@@ -32,13 +30,9 @@ class TestSwapStrategies(TestCase):
         self.mapped_paulis = [tuple(pauli) for pauli in data["paulis"]]
         self.mapped_graph = build_max_cut_graph(self.mapped_paulis)
 
-        self.sat_mapping = {
-            int(key): value for key, value in data["SAT mapping"].items()
-        }
+        self.sat_mapping = {int(key): value for key, value in data["SAT mapping"].items()}
         self.min_k = data["min swap layers"]
-        self.swap_strategy = SwapStrategy.from_line(
-            list(range(len(self.original_graph.nodes)))
-        )
+        self.swap_strategy = SwapStrategy.from_line(list(range(len(self.original_graph.nodes))))
         self.basic_graphs = [nx.path_graph(5), nx.cycle_graph(7)]
 
     def test_find_initial_mappings(self):
@@ -80,12 +74,8 @@ class TestSwapStrategies(TestCase):
         )
 
         self.assertTrue(nx.is_isomorphic(remapped_g, self.mapped_graph))
-        original_weights = {
-            data["weight"] for _, _, data in parametric_graph.edges(data=True)
-        }
-        remapped_weights = {
-            data["weight"] for _, _, data in remapped_g.edges(data=True)
-        }
+        original_weights = {data["weight"] for _, _, data in parametric_graph.edges(data=True)}
+        remapped_weights = {data["weight"] for _, _, data in remapped_g.edges(data=True)}
 
         self.assertEqual(original_weights, remapped_weights)
 

--- a/test/test_sat_mapping.py
+++ b/test/test_sat_mapping.py
@@ -1,15 +1,15 @@
 """Tests for SAT Mapping Utils"""
 
-from unittest import TestCase
 import json
 import os
-import networkx as nx
+from unittest import TestCase
 
+import networkx as nx
 from qiskit.transpiler import CouplingMap
 from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import SwapStrategy
 
-from qopt_best_practices.utils import build_max_cut_graph, build_max_cut_paulis
 from qopt_best_practices.sat_mapping import SATMapper
+from qopt_best_practices.utils import build_max_cut_graph, build_max_cut_paulis
 
 
 class TestSwapStrategies(TestCase):
@@ -19,7 +19,9 @@ class TestSwapStrategies(TestCase):
         super().setUp()
 
         # load data
-        graph_file = os.path.join(os.path.dirname(__file__), "data/graph_2layers_0seed.json")
+        graph_file = os.path.join(
+            os.path.dirname(__file__), "data/graph_2layers_0seed.json"
+        )
 
         with open(graph_file, "r") as file:
             data = json.load(file)
@@ -30,9 +32,13 @@ class TestSwapStrategies(TestCase):
         self.mapped_paulis = [tuple(pauli) for pauli in data["paulis"]]
         self.mapped_graph = build_max_cut_graph(self.mapped_paulis)
 
-        self.sat_mapping = {int(key): value for key, value in data["SAT mapping"].items()}
+        self.sat_mapping = {
+            int(key): value for key, value in data["SAT mapping"].items()
+        }
         self.min_k = data["min swap layers"]
-        self.swap_strategy = SwapStrategy.from_line(list(range(len(self.original_graph.nodes))))
+        self.swap_strategy = SwapStrategy.from_line(
+            list(range(len(self.original_graph.nodes)))
+        )
         self.basic_graphs = [nx.path_graph(5), nx.cycle_graph(7)]
 
     def test_find_initial_mappings(self):

--- a/test/test_sat_mapping.py
+++ b/test/test_sat_mapping.py
@@ -19,7 +19,9 @@ class TestSwapStrategies(TestCase):
         super().setUp()
 
         # load data
-        graph_file = os.path.join(os.path.dirname(__file__), "data/graph_2layers_0seed.json")
+        graph_file = os.path.join(
+            os.path.dirname(__file__), "data/graph_2layers_0seed.json"
+        )
 
         with open(graph_file, "r") as file:
             data = json.load(file)
@@ -30,9 +32,13 @@ class TestSwapStrategies(TestCase):
         self.mapped_paulis = [tuple(pauli) for pauli in data["paulis"]]
         self.mapped_graph = build_max_cut_graph(self.mapped_paulis)
 
-        self.sat_mapping = {int(key): value for key, value in data["SAT mapping"].items()}
+        self.sat_mapping = {
+            int(key): value for key, value in data["SAT mapping"].items()
+        }
         self.min_k = data["min swap layers"]
-        self.swap_strategy = SwapStrategy.from_line(list(range(len(self.original_graph.nodes))))
+        self.swap_strategy = SwapStrategy.from_line(
+            list(range(len(self.original_graph.nodes)))
+        )
         self.basic_graphs = [nx.path_graph(5), nx.cycle_graph(7)]
 
     def test_find_initial_mappings(self):
@@ -66,16 +72,20 @@ class TestSwapStrategies(TestCase):
 
         mapper = SATMapper()
         parametric_graph = self.original_graph.copy()
-        for i, (u, v) in enumerate(parametric_graph.edges()):
-            parametric_graph[u][v]["weight"] = f"w_{i}"
+        for i, (node1, node2) in enumerate(parametric_graph.edges()):
+            parametric_graph[node1][node2]["weight"] = f"w_{i}"
 
         remapped_g, _, _ = mapper.remap_graph_with_sat(
             graph=parametric_graph, swap_strategy=self.swap_strategy
         )
 
         self.assertTrue(nx.is_isomorphic(remapped_g, self.mapped_graph))
-        original_weights = {data["weight"] for _, _, data in parametric_graph.edges(data=True)}
-        remapped_weights = {data["weight"] for _, _, data in remapped_g.edges(data=True)}
+        original_weights = {
+            data["weight"] for _, _, data in parametric_graph.edges(data=True)
+        }
+        remapped_weights = {
+            data["weight"] for _, _, data in remapped_g.edges(data=True)
+        }
 
         self.assertEqual(original_weights, remapped_weights)
 

--- a/test/test_sat_mapping.py
+++ b/test/test_sat_mapping.py
@@ -67,6 +67,28 @@ class TestSwapStrategies(TestCase):
 
         self.assertTrue(nx.is_isomorphic(remapped_g, self.mapped_graph))
 
+    def test_remap_graph_with_sat_parametric_weights(self):
+        """Test remap_graph_with_sat preserves parametric weights"""
+
+        mapper = SATMapper()
+        parametric_graph = self.original_graph.copy()
+        for i, (u, v) in enumerate(parametric_graph.edges()):
+            parametric_graph[u][v]["weight"] = f"w_{i}"
+
+        remapped_g, _, _ = mapper.remap_graph_with_sat(
+            graph=parametric_graph, swap_strategy=self.swap_strategy
+        )
+
+        self.assertTrue(nx.is_isomorphic(remapped_g, self.mapped_graph))
+        original_weights = {
+            data["weight"] for _, _, data in parametric_graph.edges(data=True)
+        }
+        remapped_weights = {
+            data["weight"] for _, _, data in remapped_g.edges(data=True)
+        }
+
+        self.assertEqual(original_weights, remapped_weights)
+
     def test_deficient_strategy(self):
         """Test that the SAT mapper works when the SWAP strategy is deficient.
 


### PR DESCRIPTION


### Summary

Adds support for parametric Hamiltonians in SAT mapping by preserving non-numeric edge weights during graph remapping operations.


### Details and comments

1. Modified sat_mapper.py - Removed np.real() conversion when extracting edge weights from SparsePauliOp
2. Add a test for remap graph with parametric weights
3. Applied Black formatting throughout the two files in independent commits


This PR replaces #56 as a cleaner version
