### PR TITLE
Fix declared signature types in remap_graph_with_sat()

### DIFF
--- a/qopt_best_practices/sat_mapping/sat_mapper.py
+++ b/qopt_best_practices/sat_mapping/sat_mapper.py
@@ -181,9 +181,9 @@ class SATMapper:
 
     def remap_graph_with_sat(
         self,
-        graph: Union[nx.Graph | SparsePauliOp],
+        graph: nx.Graph | SparsePauliOp,
         swap_strategy: SwapStrategy,
-    ) -> tuple[int, dict, list] | tuple[None, None, None]:
+    ) -> tuple[nx.Graph | SparsePauliOp, dict, int] | tuple[None, None, None]:
         """Applies the SAT mapping.
 
         Args:
@@ -208,9 +208,9 @@ class SATMapper:
         solutions = [k for k, v in results.items() if v.satisfiable]
 
         if len(solutions):
-            min_k = min(solutions)
+            min_k: int = min(solutions)
             edge_map = dict(results[min_k].mapping)
-            remapped_graph = nx.relabel_nodes(graph, edge_map)
+            remapped_graph: nx.Graph = nx.relabel_nodes(graph, edge_map)
 
             if op_input:
                 return self.graph2op(remapped_graph), edge_map, min_k

--- a/qopt_best_practices/sat_mapping/sat_mapper.py
+++ b/qopt_best_practices/sat_mapping/sat_mapper.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from itertools import combinations
 from threading import Timer
-from typing import Union
 
 import networkx as nx
 import numpy as np


### PR DESCRIPTION
### Summary

This PR fixes the return type annotation of SATMapper.remap_graph_with_sat().

### Details and comments

The method was annotated as returning tuple[int, dict, list] | tuple[None, None, None], but the implementation actually returns:

tuple[SparsePauliOp, dict, int] when the input is a SparsePauliOp
tuple[nx.Graph, dict, int] when the input is an nx.Graph
tuple[None, None, None] when no SAT solution is found

Closes #64 